### PR TITLE
Move TxCoinAgePriority to its sole usage location.

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -584,6 +584,19 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected,
     }
 }
 
+// We want to sort transactions by coin age priority
+typedef std::pair<double, CTxMemPool::txiter> TxCoinAgePriority;
+
+struct TxCoinAgePriorityCompare {
+    bool operator()(const TxCoinAgePriority &a, const TxCoinAgePriority &b) {
+        if (a.first == b.first) {
+            // Reverse order to make sort less than
+            return CompareTxMemPoolEntryByScore()(*(b.second), *(a.second));
+        }
+        return a.first < b.first;
+    }
+};
+
 void BlockAssembler::addPriorityTxs() {
     // How much of the block should be dedicated to high-priority transactions,
     // included regardless of the fees they pay.

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -802,19 +802,6 @@ public:
     bool HaveCoin(const COutPoint &outpoint) const override;
 };
 
-// We want to sort transactions by coin age priority
-typedef std::pair<double, CTxMemPool::txiter> TxCoinAgePriority;
-
-struct TxCoinAgePriorityCompare {
-    bool operator()(const TxCoinAgePriority &a, const TxCoinAgePriority &b) {
-        if (a.first == b.first) {
-            // Reverse order to make sort less than
-            return CompareTxMemPoolEntryByScore()(*(b.second), *(a.second));
-        }
-        return a.first < b.first;
-    }
-};
-
 /**
  * DisconnectedBlockTransactions
  *


### PR DESCRIPTION
Summary:
TxCoinAgePriority is currently only used by `addPriorityTxns`.  Therefore, moving it closer will help ensure that it is removed when `addPriorityTxns` is removed.

Test Plan:
  make check && ./test/functional/test_runner.py

Tags: #cleanup