### PR TITLE
Enforce Logos coinbase rule on testnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -230,8 +230,8 @@ public:
             .nTimeout = 1230767999,
         };
 
-        // The miner fund is disabled by default on testnet.
-        consensus.enableMinerFund = false;
+        // The miner fund is enabled by default on testnet.
+        consensus.enableMinerFund = ENABLE_MINER_FUND;
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork =


### PR DESCRIPTION
Testnet coins are worthless anyway; this will allow mining pools to test their setup.
It'll also allow us to test new coinbase outputs on the testnet.