### PR TITLE
Make non-pushonly scriptsig in coinbase inputs standard

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -88,7 +88,8 @@ bool IsStandardTx(const CTransaction &tx, bool permit_bare_multisig,
             reason = "scriptsig-size";
             return false;
         }
-        if (!txin.scriptSig.IsPushOnly()) {
+        // Coinbase can have non-pushonly scriptSig
+        if (!tx.IsCoinBase() && !txin.scriptSig.IsPushOnly()) {
             reason = "scriptsig-not-pushonly";
             return false;
         }

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -885,9 +885,17 @@ BOOST_AUTO_TEST_CASE(test_IsStandard) {
         uint8_t orig_op = *prev_pc;
         // replace current push-op with each non-push-op
         for (auto op : non_push_ops) {
+            // save prevout
+            COutPoint prevout = t.vin[0].prevout;
             t.vin[0].scriptSig[index] = op;
             BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
             BOOST_CHECK_EQUAL(reason, "scriptsig-not-pushonly");
+
+            // make input coinbase, then scriptsig-not-pushonly does not apply
+            t.vin[0].prevout = COutPoint();
+            BOOST_CHECK(IsStandardTx(CTransaction(t), reason));
+            // restore prevout
+            t.vin[0].prevout = prevout;
         }
         // restore op
         t.vin[0].scriptSig[index] = orig_op;


### PR DESCRIPTION
Currently, non-pushonly scriptSigs are non-standard; but mining pool software relies on the scriptSig of the coinbase being arbitray.
We enforce standardness on all txs, so blocks having non-pushonly coinbases scriptSigs will be rejected, which is not what we want.

This will remove the "scriptsig-not-pushonly" restriction for standardness on coinbase inputs.