### PR TITLE
Update QAPP_* constants

### DIFF
--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -42,11 +42,11 @@ static const int TOOLTIP_WRAP_THRESHOLD = 80;
 /* Number of frames in spinner animation */
 #define SPINNER_FRAMES 36
 
-#define QAPP_ORG_NAME "BitcoinABC"
-#define QAPP_ORG_DOMAIN "bitcoinabc.org"
-#define QAPP_APP_NAME_DEFAULT "BitcoinABC-Qt"
-#define QAPP_APP_NAME_TESTNET "BitcoinABC-Qt-testnet"
-#define QAPP_APP_NAME_REGTEST "BitcoinABC-Qt-regtest"
+#define QAPP_ORG_NAME "LogosFoundation"
+#define QAPP_ORG_DOMAIN "logos.cash"
+#define QAPP_APP_NAME_DEFAULT "Lotus-Qt"
+#define QAPP_APP_NAME_TESTNET "Lotus-Qt-testnet"
+#define QAPP_APP_NAME_REGTEST "Lotus-Qt-regtest"
 
 /* One gigabyte (GB) in bytes */
 static constexpr uint64_t GB_BYTES{1'000'000'000};


### PR DESCRIPTION
This fixes a bug where the Qt wallet would use the old Bitcoin ABC datadir, causing all sorts of problems