### PR TITLE
Refactor GetBlockSubsidy to depend on nBits instead of nHeight

### DIFF
--- a/src/bench/duplicate_inputs.cpp
+++ b/src/bench/duplicate_inputs.cpp
@@ -46,7 +46,7 @@ static void DuplicateInputs(benchmark::Bench &bench) {
     coinbaseTx.vin[0].prevout = COutPoint();
     coinbaseTx.vout.resize(1);
     coinbaseTx.vout[0].scriptPubKey = SCRIPT_PUB;
-    coinbaseTx.vout[0].nValue = GetBlockSubsidy(nHeight, consensusParams);
+    coinbaseTx.vout[0].nValue = GetBlockSubsidy(block.nBits, consensusParams);
     coinbaseTx.vin[0].scriptSig = CScript() << COINBASE_PREFIX
                                             << nHeight
                                             << OP_0;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2405,7 +2405,7 @@ static UniValue getblockstats(const Config &config,
     ret_all.pushKV("mintxsize", mintxsize == blockMaxSize ? 0 : mintxsize);
     ret_all.pushKV("outs", outputs);
     ret_all.pushKV("subsidy", ValueFromAmount(GetBlockSubsidy(
-                                  pindex->nHeight, Params().GetConsensus())));
+                                  pindex->nBits, Params().GetConsensus())));
     ret_all.pushKV("time", pindex->GetBlockTime());
     ret_all.pushKV("total_out", ValueFromAmount(total_out));
     ret_all.pushKV("total_size", total_size);

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -30,12 +30,36 @@ BOOST_FIXTURE_TEST_SUITE(validation_tests, TestingSetup)
  * Make sure the block subsidy is really constant.
  */
 static void TestBlockSubsidyConstant(const Consensus::Params &consensusParams) {
-    BOOST_CHECK_EQUAL(SUBSIDY, GetBlockSubsidy(0, consensusParams));
-    BOOST_CHECK_EQUAL(SUBSIDY, GetBlockSubsidy(1, consensusParams));
-    BOOST_CHECK_EQUAL(SUBSIDY, GetBlockSubsidy(100'000, consensusParams));
-    BOOST_CHECK_EQUAL(SUBSIDY, GetBlockSubsidy(210'000, consensusParams));
-    BOOST_CHECK_EQUAL(SUBSIDY, GetBlockSubsidy(210'001, consensusParams));
-    BOOST_CHECK_EQUAL(SUBSIDY, GetBlockSubsidy(0x7fff'ffff, consensusParams));
+    BOOST_CHECK_EQUAL(SUBSIDY, GetBlockSubsidy(0x1d00ffff, consensusParams));
+    BOOST_CHECK_EQUAL(SUBSIDY, GetBlockSubsidy(0x1d008000, consensusParams));
+    BOOST_CHECK_EQUAL(SUBSIDY, GetBlockSubsidy(0x1e7fffff, consensusParams));
+    BOOST_CHECK_EQUAL(
+        SUBSIDY,
+        GetBlockSubsidy(0x1c2a1115, consensusParams)); // block 50000 on BTC
+    BOOST_CHECK_EQUAL(
+        SUBSIDY,
+        GetBlockSubsidy(0x1b04864c, consensusParams)); // block 100000 on BTC
+    BOOST_CHECK_EQUAL(
+        SUBSIDY,
+        GetBlockSubsidy(0x1a05db8b, consensusParams)); // block 200000 on BTC
+    BOOST_CHECK_EQUAL(
+        SUBSIDY,
+        GetBlockSubsidy(0x1900896c, consensusParams)); // block 300000 on BTC
+    BOOST_CHECK_EQUAL(
+        SUBSIDY,
+        GetBlockSubsidy(0x1806b99f, consensusParams)); // block 400000 on BTC
+    BOOST_CHECK_EQUAL(
+        SUBSIDY,
+        GetBlockSubsidy(0x18009645, consensusParams)); // block 500000 on BTC
+    BOOST_CHECK_EQUAL(
+        SUBSIDY,
+        GetBlockSubsidy(0x1715a35c, consensusParams)); // block 600000 on BTC
+    BOOST_CHECK_EQUAL(
+        SUBSIDY,
+        GetBlockSubsidy(0x170bef93, consensusParams)); // block 680603 on BTC
+    BOOST_CHECK_EQUAL(SUBSIDY, GetBlockSubsidy(0x1000ffff, consensusParams));
+    BOOST_CHECK_EQUAL(SUBSIDY, GetBlockSubsidy(0x0500ffff, consensusParams));
+    BOOST_CHECK_EQUAL(SUBSIDY, GetBlockSubsidy(0x0300ffff, consensusParams));
 }
 
 static void TestBlockSubsidyConstant(int nSubsidyHalvingInterval) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -860,7 +860,8 @@ static bool WriteBlockToDisk(const CBlock &block, FlatFilePos &pos,
     return true;
 }
 
-Amount GetBlockSubsidy(int nHeight, const Consensus::Params &consensusParams) {
+Amount GetBlockSubsidy(uint32_t nBits,
+                       const Consensus::Params &consensusParams) {
     return SUBSIDY;
 }
 
@@ -1847,7 +1848,7 @@ bool CChainState::ConnectBlock(const CBlock &block, BlockValidationState &state,
     // 50% of fees get burned.
     Amount amountFeeReward = nFees / 2;
     Amount blockReward =
-        amountFeeReward + GetBlockSubsidy(pindex->nHeight, consensusParams);
+        amountFeeReward + GetBlockSubsidy(block.nBits, consensusParams);
     if (block.vtx[0]->GetValueOut() > blockReward) {
         LogPrintf("ERROR: ConnectBlock(): coinbase pays too much (actual=%d vs "
                   "limit=%d)\n",

--- a/src/validation.h
+++ b/src/validation.h
@@ -249,7 +249,8 @@ bool GetTransaction(const TxId &txid, CTransactionRef &txOut,
 bool ActivateBestChain(
     const Config &config, BlockValidationState &state,
     std::shared_ptr<const CBlock> pblock = std::shared_ptr<const CBlock>());
-Amount GetBlockSubsidy(int nHeight, const Consensus::Params &consensusParams);
+Amount GetBlockSubsidy(uint32_t nBits,
+                       const Consensus::Params &consensusParams);
 
 /**
  * Guess verification progress (as a fraction between 0.0=genesis and


### PR DESCRIPTION
This will allow us to build a coin where the block reward depends on difficulty.