### PR TITLE
Update default ports to be based off p2p port 10605

### DIFF
--- a/contrib/aur/common/bitcoin.conf
+++ b/contrib/aur/common/bitcoin.conf
@@ -1,4 +1,4 @@
-rpcport=8332
+rpcport=10604
 rpcuser=bitcoin
 rpcpassword=secret
 rpcallowip=127.0.0.1

--- a/contrib/aur/common/bitcoin.install
+++ b/contrib/aur/common/bitcoin.install
@@ -46,7 +46,7 @@ To communicate with bitcoin-abc as a normal user:
 
 $ mkdir -p ~/.bitcoin
 $ cat > ~/.bitcoin/bitcoin.conf <<'EOF'
-rpcport=8332
+rpcport=10604
 rpcuser=bitcoin
 rpcpassword=secret
 EOF

--- a/contrib/debian/examples/bitcoin.conf
+++ b/contrib/debian/examples/bitcoin.conf
@@ -44,11 +44,11 @@
 
 # Use as many addnode= settings as you like to connect to specific peers
 #addnode=69.164.218.197
-#addnode=10.0.0.2:8333
+#addnode=10.0.0.2:10605
 
 # Alternatively use as many connect= settings as you like to connect ONLY to specific peers
 #connect=69.164.218.197
-#connect=10.0.0.1:8333
+#connect=10.0.0.1:10605
 
 # Listening mode, enabled by default except when 'connect' is being used
 #listen=1
@@ -110,7 +110,7 @@
 #rpcallowip=2001:db8:85a3:0:0:8a2e:370:7334/96
 
 # Listen for RPC connections on this TCP port:
-#rpcport=8332
+#rpcport=10604
 
 # You can use Bitcoin or bitcoind to send commands to Bitcoin/bitcoind
 # running on another host using this option:

--- a/contrib/devtools/chainparams/README.md
+++ b/contrib/devtools/chainparams/README.md
@@ -17,7 +17,7 @@ make_chainparams > chainparams_main.txt
 ## Testnet
 ```
 bitcoind --testnet
-make_chainparams -a 127.0.0.1:18332 > chainparams_test.txt
+make_chainparams -a 127.0.0.1:11604 > chainparams_test.txt
 ```
 
 ## Build C++ Header File

--- a/contrib/devtools/chainparams/make_chainparams.py
+++ b/contrib/devtools/chainparams/make_chainparams.py
@@ -77,10 +77,10 @@ if __name__ == "__main__":
         "Make chainparams file.\n"
         "Prerequisites: RPC access to a bitcoind node.\n\n"),
         formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument('--address', '-a', default="127.0.0.1:8332",
+    parser.add_argument('--address', '-a', default="127.0.0.1:10604",
                         help="Node address for making RPC calls.\n"
                              "The chain (MainNet or TestNet) will be automatically detected.\n"
-                             "Default: '127.0.0.1:8332'")
+                             "Default: '127.0.0.1:10604'")
     parser.add_argument('--block', '-b',
                         help="The block hash or height to use for fetching chainparams.\n"
                              "MainNet default: 10 blocks from the chain tip."

--- a/contrib/docker/bitcoin-abc/Dockerfile
+++ b/contrib/docker/bitcoin-abc/Dockerfile
@@ -21,7 +21,7 @@ RUN chown -h bitcoin:bitcoin /home/bitcoin/.bitcoin
 # are set, otherwise the changes won't be persistent
 VOLUME "${BITCOIN_DATA}"
 
-EXPOSE 8332 8333 18332 18333
+EXPOSE 10604 10605 11604 11605
 
 USER bitcoin
 CMD ["bitcoind"]

--- a/contrib/linearize/README.md
+++ b/contrib/linearize/README.md
@@ -11,7 +11,7 @@ Required configuration file settings for linearize-hashes:
 
 Optional config file setting for linearize-hashes:
 * RPC: `host`  (Default: `127.0.0.1`)
-* RPC: `port`  (Default: `8332`)
+* RPC: `port`  (Default: `10604`)
 * Blockchain: `min_height`, `max_height`
 * `rev_hash_bytes`: If true, the written block hash list will be
 byte-reversed. (In other words, the hash returned by getblockhash will have its

--- a/contrib/linearize/example-linearize.cfg
+++ b/contrib/linearize/example-linearize.cfg
@@ -5,13 +5,13 @@ rpcpassword=somepassword
 host=127.0.0.1
 
 #mainnet default
-port=8332
+port=10604
 
 #testnet default
-#port=18332
+#port=11604
 
 #regtest default
-#port=18443
+#port=12604
 
 # bootstrap.dat hashlist settings (linearize-hashes)
 max_height=313000

--- a/contrib/linearize/linearize-hashes.py
+++ b/contrib/linearize/linearize-hashes.py
@@ -131,7 +131,7 @@ if __name__ == '__main__':
     if 'host' not in settings:
         settings['host'] = '127.0.0.1'
     if 'port' not in settings:
-        settings['port'] = 8332
+        settings['port'] = 10604
     if 'min_height' not in settings:
         settings['min_height'] = 0
     if 'max_height' not in settings:

--- a/contrib/qos/README.md
+++ b/contrib/qos/README.md
@@ -1,5 +1,5 @@
 ### QoS (Quality of service) ###
 
-This is a Linux bash script that will set up tc to limit the outgoing bandwidth for connections to the Bitcoin network. It limits outbound TCP traffic with a source or destination port of 8333, but not if the destination IP is within a LAN.
+This is a Linux bash script that will set up tc to limit the outgoing bandwidth for connections to the Bitcoin network. It limits outbound TCP traffic with a source or destination port of 10605, but not if the destination IP is within a LAN.
 
 This means one can have an always-on bitcoind instance running, and another local bitcoind/bitcoin-qt instance which connects to this node and receives blocks from it.

--- a/contrib/qos/tc.sh
+++ b/contrib/qos/tc.sh
@@ -47,16 +47,16 @@ fi
 #	ret=$?
 #done
 
-#limit outgoing traffic to and from port 8333. but not when dealing with a host on the local network
+#limit outgoing traffic to and from port 10605. but not when dealing with a host on the local network
 #	(defined by $LOCALNET_V4 and $LOCALNET_V6)
 #	--set-mark marks packages matching these criteria with the number "2" (v4)
 #	--set-mark marks packages matching these criteria with the number "4" (v6)
 #	these packets are filtered by the tc filter with "handle 2"
 #	this filter sends the packages into the 1:11 class, and this class is limited to ${LIMIT}
-iptables -t mangle -A OUTPUT -p tcp -m tcp --dport 8333 ! -d ${LOCALNET_V4} -j MARK --set-mark 0x2
-iptables -t mangle -A OUTPUT -p tcp -m tcp --sport 8333 ! -d ${LOCALNET_V4} -j MARK --set-mark 0x2
+iptables -t mangle -A OUTPUT -p tcp -m tcp --dport 10605 ! -d ${LOCALNET_V4} -j MARK --set-mark 0x2
+iptables -t mangle -A OUTPUT -p tcp -m tcp --sport 10605 ! -d ${LOCALNET_V4} -j MARK --set-mark 0x2
 
 if [ -n "${LOCALNET_V6}" ] ; then
-	ip6tables -t mangle -A OUTPUT -p tcp -m tcp --dport 8333 ! -d ${LOCALNET_V6} -j MARK --set-mark 0x4
-	ip6tables -t mangle -A OUTPUT -p tcp -m tcp --sport 8333 ! -d ${LOCALNET_V6} -j MARK --set-mark 0x4
+	ip6tables -t mangle -A OUTPUT -p tcp -m tcp --dport 10605 ! -d ${LOCALNET_V6} -j MARK --set-mark 0x4
+	ip6tables -t mangle -A OUTPUT -p tcp -m tcp --sport 10605 ! -d ${LOCALNET_V6} -j MARK --set-mark 0x4
 fi

--- a/contrib/seeds/generate-seeds.py
+++ b/contrib/seeds/generate-seeds.py
@@ -137,10 +137,10 @@ def main():
         ' * IPv4 as well as onion addresses are wrapped inside an IPv6 address accordingly.\n')
     g.write(' */\n')
     with open(os.path.join(indir, 'nodes_main.txt'), 'r', encoding="utf8") as f:
-        process_nodes(g, f, 'pnSeed6_main', 8333)
+        process_nodes(g, f, 'pnSeed6_main', 10605)
     g.write('\n')
     with open(os.path.join(indir, 'nodes_test.txt'), 'r', encoding="utf8") as f:
-        process_nodes(g, f, 'pnSeed6_test', 18333)
+        process_nodes(g, f, 'pnSeed6_test', 11605)
     g.write('#endif // BITCOIN_CHAINPARAMSSEEDS_H\n')
 
 

--- a/contrib/source-control-tools/patch-recipes/update-chainparams.sh
+++ b/contrib/source-control-tools/patch-recipes/update-chainparams.sh
@@ -10,7 +10,7 @@ CHAINPARAMS_SCRIPTS_DIR="${TOPLEVEL}"/contrib/devtools/chainparams
 # ARGS should be triplets of network, mainnet port, testnet port, ...
 ARGS=("$@")
 if [ "$#" == 0 ]; then
-  ARGS=("abc" 8332 18332)
+  ARGS=("abc" 10604 11604)
 fi
 
 # Assumes bitcoind instances are already running on mainnet and testnet

--- a/contrib/zmq/zmq_sub.py
+++ b/contrib/zmq/zmq_sub.py
@@ -8,10 +8,10 @@
 
     Bitcoin should be started with the command line arguments:
         bitcoind -testnet -daemon \
-                -zmqpubrawtx=tcp://127.0.0.1:28332 \
-                -zmqpubrawblock=tcp://127.0.0.1:28332 \
-                -zmqpubhashtx=tcp://127.0.0.1:28332 \
-                -zmqpubhashblock=tcp://127.0.0.1:28332
+                -zmqpubrawtx=tcp://127.0.0.1:13604 \
+                -zmqpubrawblock=tcp://127.0.0.1:13604 \
+                -zmqpubhashtx=tcp://127.0.0.1:13604 \
+                -zmqpubhashblock=tcp://127.0.0.1:13604
 
     We use the asyncio library here.  `self.handle()` installs itself as a
     future at the end of the function.  Since it never returns with the event
@@ -34,7 +34,7 @@ if not (sys.version_info.major >= 3 and sys.version_info.minor >= 5):
     print("This example only works with Python 3.5 and greater")
     sys.exit(1)
 
-port = 28332
+port = 13604
 ip = "172.31.9.161"
 
 

--- a/doc/JSON-RPC-interface.md
+++ b/doc/JSON-RPC-interface.md
@@ -69,7 +69,7 @@ RPC interface will be abused.
     need to expose the RPC port to the host system.  The default way to
     do this in Docker also exposes the port to the public Internet.
     Instead, expose it only on the host system's localhost, for example:
-    `-p 127.0.0.1:8332:8332`
+    `-p 127.0.0.1:10604:10604`
 
 - **Secure authentication:** By default, Bitcoin ABC generates unique
   login credentials each time it restarts and puts them into a file

--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -3,7 +3,7 @@ Unauthenticated REST Interface
 
 The REST API can be enabled with the `-rest` option.
 
-The interface runs on the same port as the JSON-RPC interface, by default port 8332 for mainnet, port 18332 for testnet, and port 18443 for regtest.
+The interface runs on the same port as the JSON-RPC interface, by default port 10604 for mainnet, port 11604 for testnet, and port 12604 for regtest.
 
 REST Interface consistency guarantees
 -------------------------------------
@@ -69,7 +69,7 @@ See BIP64 for input and output serialisation:
 
 Example:
 ```
-$ curl localhost:18332/rest/getutxos/checkmempool/b2cdfd7b89def827ff8af7cd9bff7627ff72e5e8b0f71210f92ea7a4000c5d75-0.json 2>/dev/null | json_pp
+$ curl localhost:11604/rest/getutxos/checkmempool/b2cdfd7b89def827ff8af7cd9bff7627ff72e5e8b0f71210f92ea7a4000c5d75-0.json 2>/dev/null | json_pp
 {
    "chaintipHash" : "00000000fb01a7f3745a717f8caebee056c484e6e0bfe4a9591c235bb70506fb",
    "chainHeight" : 325347,
@@ -110,4 +110,4 @@ Only supports JSON as output format.
 
 Risks
 -------------
-Running a web browser on the same node with a REST enabled bitcoind can be a risk. Accessing prepared XSS websites could read out tx/block data of your node by placing links like `<script src="http://127.0.0.1:8332/rest/tx/1234567890.json">` which might break the nodes privacy.
+Running a web browser on the same node with a REST enabled bitcoind can be a risk. Accessing prepared XSS websites could read out tx/block data of your node by placing links like `<script src="http://127.0.0.1:10604/rest/tx/1234567890.json">` which might break the nodes privacy.

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -520,7 +520,7 @@ Threads
     : Universal plug-and-play startup/shutdown.
 
   - [ThreadSocketHandler (`b-net`)](https://www.bitcoinabc.org/doc/dev/class_c_connman.html#a765597cbfe99c083d8fa3d61bb464e34)
-    : Sends/Receives data from peers on port 8333.
+    : Sends/Receives data from peers on port 10605.
 
   - [ThreadOpenAddedConnections (`b-addcon`)](https://www.bitcoinabc.org/doc/dev/class_c_connman.html#a0b787caf95e52a346a2b31a580d60a62)
     : Opens network connections to added nodes.

--- a/doc/release-notes/release-notes-0.10.0.md
+++ b/doc/release-notes/release-notes-0.10.0.md
@@ -142,10 +142,10 @@ unauthenticated access to public node data.
 It is served on the same port as RPC, but does not need a password, and uses
 plain HTTP instead of JSON-RPC.
 
-Assuming a local RPC server running on port 8332, it is possible to request:
-- Blocks: http://localhost:8332/rest/block/*HASH*.*EXT*
-- Blocks without transactions: http://localhost:8332/rest/block/notxdetails/*HASH*.*EXT*
-- Transactions (requires `-txindex`): http://localhost:8332/rest/tx/*HASH*.*EXT*
+Assuming a local RPC server running on port 10604, it is possible to request:
+- Blocks: http://localhost:10604/rest/block/*HASH*.*EXT*
+- Blocks without transactions: http://localhost:10604/rest/block/notxdetails/*HASH*.*EXT*
+- Transactions (requires `-txindex`): http://localhost:10604/rest/tx/*HASH*.*EXT*
 
 In every case, *EXT* can be `bin` (for raw binary data), `hex` (for hex-encoded
 binary) or `json`.

--- a/doc/release-notes/release-notes-0.21.6.md
+++ b/doc/release-notes/release-notes-0.21.6.md
@@ -16,7 +16,7 @@ This release includes the following features and fixes:
    commands over a public network connection is insecure and should be
    disabled, so a warning is now printed if a user selects such a
    configuration. If you need to expose RPC in order to use a tool
-   like Docker, ensure you only bind RPC to your localhost, e.g. docker run [...] -p 127.0.0.1:8332:8332 (this is an extra :8332 over the
+   like Docker, ensure you only bind RPC to your localhost, e.g. docker run [...] -p 127.0.0.1:10604:10604 (this is an extra :10604 over the
    normal Docker port specification).
  - The `getmininginfo` RPC now omits `currentblocksize` and `currentblocktx`
    when a block was never assembled via RPC on this node.

--- a/doc/release-notes/release-notes-0.22.10.md
+++ b/doc/release-notes/release-notes-0.22.10.md
@@ -24,7 +24,7 @@ Command line
 ------------
 
 Command line options prefixed with main/test/regtest network names like
-`-main.port=8333` `-test.server=1` previously were allowed but ignored. Now
+`-main.port=10605` `-test.server=1` previously were allowed but ignored. Now
 they trigger "Invalid parameter" errors on startup.
 
 Light Clients

--- a/doc/release-notes/release-notes-0.7.1.md
+++ b/doc/release-notes/release-notes-0.7.1.md
@@ -77,7 +77,7 @@ Bug fixes
 
 * Clicking on a bitcoin: URI on Windows should now launch Bitcoin-Qt properly.
 
-* When running -testnet, use RPC port 18332 by default.
+* When running -testnet, use RPC port 11604 by default.
 
 * Better detection and handling of corrupt wallet.dat and blkindex.dat files.
   Previous versions would crash with a DB_RUNRECOVERY exception, this

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -45,11 +45,11 @@ config file): *Needed for Tor version 0.2.7.0 and older versions of Tor only. Fo
 versions of Tor see [Section 3](#3-automatically-listen-on-tor).*
 
 	HiddenServiceDir /var/lib/tor/bitcoin-service/
-	HiddenServicePort 8333 127.0.0.1:8333
-	HiddenServicePort 18333 127.0.0.1:18333
+	HiddenServicePort 10605 127.0.0.1:10605
+	HiddenServicePort 11605 127.0.0.1:11605
 
 The directory can be different of course, but (both) port numbers should be equal to
-your bitcoind's P2P listen port (8333 by default).
+your bitcoind's P2P listen port (10605 by default).
 
 	-externalip=X   You can tell bitcoin about its publicly reachable address using
 	                this option, and this can be a .onion address. Given the above
@@ -84,7 +84,7 @@ as well, use `discover` instead:
 
 	./bitcoind ... -discover
 
-and open port 8333 on your firewall (or use -upnp).
+and open port 10605 on your firewall (or use -upnp).
 
 If you only want to use Tor to reach .onion addresses, but not use it as a proxy
 for normal IPv4/IPv6 communication, use:

--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -77,7 +77,7 @@ The high water mark value must be an integer greater than or equal to 0.
 
 For instance:
 
-    $ bitcoind -zmqpubhashtx=tcp://127.0.0.1:28332 \
+    $ bitcoind -zmqpubhashtx=tcp://127.0.0.1:13604 \
                -zmqpubrawtx=ipc:///tmp/bitcoind.tx.raw \
                -zmqpubhashtxhwm=10000
 

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -133,7 +133,7 @@ static void SetupCliArgs(ArgsManager &argsman) {
         "-rpcwallet=<walletname>",
         "Send RPC for non-default wallet on RPC server (needs to exactly match "
         "corresponding -wallet option passed to bitcoind). This changes the "
-        "RPC endpoint used, e.g. http://127.0.0.1:8332/wallet/<walletname>",
+        "RPC endpoint used, e.g. http://127.0.0.1:10604/wallet/<walletname>",
         ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 }
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -139,7 +139,7 @@ public:
         netMagic[1] = 0xe7;
         netMagic[2] = 0xef;
         netMagic[3] = 0xf3;
-        nDefaultPort = 8333;
+        nDefaultPort = 10605;
         nPruneAfterHeight = 100000;
         m_assumed_blockchain_size =
             ChainParamsConstants::MAINNET_ASSUMED_BLOCKCHAIN_SIZE;
@@ -263,7 +263,7 @@ public:
         netMagic[1] = 0xf4;
         netMagic[2] = 0xf3;
         netMagic[3] = 0xf4;
-        nDefaultPort = 18333;
+        nDefaultPort = 11605;
         nPruneAfterHeight = 1000;
         m_assumed_blockchain_size =
             ChainParamsConstants::TESTNET_ASSUMED_BLOCKCHAIN_SIZE;
@@ -365,7 +365,7 @@ public:
         netMagic[1] = 0xf2;
         netMagic[2] = 0xe5;
         netMagic[3] = 0xe7;
-        nDefaultPort = 18444;
+        nDefaultPort = 12605;
         nPruneAfterHeight = 1000;
         m_assumed_blockchain_size = 0;
         m_assumed_chain_state_size = 0;

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -41,15 +41,15 @@ const CBaseChainParams &BaseParams() {
 std::unique_ptr<CBaseChainParams>
 CreateBaseChainParams(const std::string &chain) {
     if (chain == CBaseChainParams::MAIN) {
-        return std::make_unique<CBaseChainParams>("", 8332);
+        return std::make_unique<CBaseChainParams>("", 10604);
     }
 
     if (chain == CBaseChainParams::TESTNET) {
-        return std::make_unique<CBaseChainParams>("testnet3", 18332);
+        return std::make_unique<CBaseChainParams>("testnet3", 11604);
     }
 
     if (chain == CBaseChainParams::REGTEST) {
-        return std::make_unique<CBaseChainParams>("regtest", 18443);
+        return std::make_unique<CBaseChainParams>("regtest", 12604);
     }
 
     throw std::runtime_error(

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -202,7 +202,7 @@ bool LookupHost(const std::string &name, CNetAddr &addr, bool fAllowLookup) {
  * @param name    The string representing a service. Could be a name or a
  *                numerical IP address (IPv6 addresses should be in their
  *                disambiguated bracketed form), optionally followed by a port
- *                number. (e.g. example.com:8333 or
+ *                number. (e.g. example.com:10605 or
  *                [2001:db8:85a3:8d3:1319:8a2e:370:7348]:420)
  * @param[out] vAddr The resulting services to which the specified service
  * string resolved.

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -323,8 +323,8 @@ static UniValue addnode(const Config &config, const JSONRPCRequest &request) {
             },
             RPCResult{RPCResult::Type::NONE, "", ""},
             RPCExamples{
-                HelpExampleCli("addnode", "\"192.168.0.6:8333\" \"onetry\"") +
-                HelpExampleRpc("addnode", "\"192.168.0.6:8333\", \"onetry\"")},
+                HelpExampleCli("addnode", "\"192.168.0.6:10605\" \"onetry\"") +
+                HelpExampleRpc("addnode", "\"192.168.0.6:10605\", \"onetry\"")},
         }
                                      .ToString());
     }
@@ -375,9 +375,9 @@ static UniValue disconnectnode(const Config &config,
              "The node ID (see getpeerinfo for node IDs)"},
         },
         RPCResult{RPCResult::Type::NONE, "", ""},
-        RPCExamples{HelpExampleCli("disconnectnode", "\"192.168.0.6:8333\"") +
+        RPCExamples{HelpExampleCli("disconnectnode", "\"192.168.0.6:10605\"") +
                     HelpExampleCli("disconnectnode", "\"\" 1") +
-                    HelpExampleRpc("disconnectnode", "\"192.168.0.6:8333\"") +
+                    HelpExampleRpc("disconnectnode", "\"192.168.0.6:10605\"") +
                     HelpExampleRpc("disconnectnode", "\"\", 1")},
     }
         .Check(request);

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -146,7 +146,7 @@ std::string HelpExampleRpc(const std::string &methodname,
            "\"id\": \"curltest\", "
            "\"method\": \"" +
            methodname + "\", \"params\": [" + args +
-           "]}' -H 'content-type: text/plain;' http://127.0.0.1:8332/\n";
+           "]}' -H 'content-type: text/plain;' http://127.0.0.1:10604/\n";
 }
 
 // Converts a hex string to a public key if possible

--- a/src/seeder/test/p2p_messaging_tests.cpp
+++ b/src/seeder/test/p2p_messaging_tests.cpp
@@ -40,7 +40,7 @@ public:
 };
 } // namespace
 
-static const unsigned short SERVICE_PORT = 18444;
+static const unsigned short SERVICE_PORT = 12605;
 
 struct SeederTestingSetup {
     SeederTestingSetup() {

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -127,15 +127,15 @@ BOOST_AUTO_TEST_CASE(addrman_simple) {
     BOOST_CHECK_EQUAL(addr_null.ToString(), "[::]:0");
 
     // Test: Does Addrman::Add work as expected.
-    CService addr1 = ResolveService("250.1.1.1", 8333);
+    CService addr1 = ResolveService("250.1.1.1", 10605);
     BOOST_CHECK(addrman.Add(CAddress(addr1, NODE_NONE), source));
     BOOST_CHECK_EQUAL(addrman.size(), 1U);
     CAddrInfo addr_ret1 = addrman.Select();
-    BOOST_CHECK_EQUAL(addr_ret1.ToString(), "250.1.1.1:8333");
+    BOOST_CHECK_EQUAL(addr_ret1.ToString(), "250.1.1.1:10605");
 
     // Test: Does IP address deduplication work correctly.
     //  Expected dup IP should not be added.
-    CService addr1_dup = ResolveService("250.1.1.1", 8333);
+    CService addr1_dup = ResolveService("250.1.1.1", 10605);
     BOOST_CHECK(!addrman.Add(CAddress(addr1_dup, NODE_NONE), source));
     BOOST_CHECK_EQUAL(addrman.size(), 1U);
 
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(addrman_simple) {
     // Note that addrman's size cannot be tested reliably after insertion, as
     // hash collisions may occur. But we can always be sure of at least one
     // success.
-    CService addr2 = ResolveService("250.1.1.2", 8333);
+    CService addr2 = ResolveService("250.1.1.2", 10605);
     BOOST_CHECK(addrman.Add(CAddress(addr2, NODE_NONE), source));
     BOOST_CHECK(addrman.size() >= 1);
 
@@ -156,8 +156,8 @@ BOOST_AUTO_TEST_CASE(addrman_simple) {
 
     // Test: AddrMan::Add multiple addresses works as expected
     std::vector<CAddress> vAddr;
-    vAddr.push_back(CAddress(ResolveService("250.1.1.3", 8333), NODE_NONE));
-    vAddr.push_back(CAddress(ResolveService("250.1.1.4", 8333), NODE_NONE));
+    vAddr.push_back(CAddress(ResolveService("250.1.1.3", 10605), NODE_NONE));
+    vAddr.push_back(CAddress(ResolveService("250.1.1.4", 10605), NODE_NONE));
     BOOST_CHECK(addrman.Add(vAddr, source));
     BOOST_CHECK(addrman.size() >= 1);
 }
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(addrman_ports) {
     BOOST_CHECK_EQUAL(addrman.size(), 0U);
 
     // Test: Addr with same IP but diff port does not replace existing addr.
-    CService addr1 = ResolveService("250.1.1.1", 8333);
+    CService addr1 = ResolveService("250.1.1.1", 10605);
     BOOST_CHECK(addrman.Add(CAddress(addr1, NODE_NONE), source));
     BOOST_CHECK_EQUAL(addrman.size(), 1U);
 
@@ -178,7 +178,7 @@ BOOST_AUTO_TEST_CASE(addrman_ports) {
     BOOST_CHECK(!addrman.Add(CAddress(addr1_port, NODE_NONE), source));
     BOOST_CHECK_EQUAL(addrman.size(), 1U);
     CAddrInfo addr_ret2 = addrman.Select();
-    BOOST_CHECK_EQUAL(addr_ret2.ToString(), "250.1.1.1:8333");
+    BOOST_CHECK_EQUAL(addr_ret2.ToString(), "250.1.1.1:10605");
 
     // Test: Add same IP but diff port to tried table, it doesn't get added.
     //  Perhaps this is not ideal behavior but it is the current behavior.
@@ -186,7 +186,7 @@ BOOST_AUTO_TEST_CASE(addrman_ports) {
     BOOST_CHECK_EQUAL(addrman.size(), 1U);
     bool newOnly = true;
     CAddrInfo addr_ret3 = addrman.Select(newOnly);
-    BOOST_CHECK_EQUAL(addr_ret3.ToString(), "250.1.1.1:8333");
+    BOOST_CHECK_EQUAL(addr_ret3.ToString(), "250.1.1.1:10605");
 }
 
 BOOST_AUTO_TEST_CASE(addrman_select) {
@@ -195,13 +195,13 @@ BOOST_AUTO_TEST_CASE(addrman_select) {
     CNetAddr source = ResolveIP("252.2.2.2");
 
     // Test: Select from new with 1 addr in new.
-    CService addr1 = ResolveService("250.1.1.1", 8333);
+    CService addr1 = ResolveService("250.1.1.1", 10605);
     BOOST_CHECK(addrman.Add(CAddress(addr1, NODE_NONE), source));
     BOOST_CHECK_EQUAL(addrman.size(), 1U);
 
     bool newOnly = true;
     CAddrInfo addr_ret1 = addrman.Select(newOnly);
-    BOOST_CHECK_EQUAL(addr_ret1.ToString(), "250.1.1.1:8333");
+    BOOST_CHECK_EQUAL(addr_ret1.ToString(), "250.1.1.1:10605");
 
     // Test: move addr to tried, select from new expected nothing returned.
     addrman.Good(CAddress(addr1, NODE_NONE));
@@ -210,35 +210,35 @@ BOOST_AUTO_TEST_CASE(addrman_select) {
     BOOST_CHECK_EQUAL(addr_ret2.ToString(), "[::]:0");
 
     CAddrInfo addr_ret3 = addrman.Select();
-    BOOST_CHECK_EQUAL(addr_ret3.ToString(), "250.1.1.1:8333");
+    BOOST_CHECK_EQUAL(addr_ret3.ToString(), "250.1.1.1:10605");
 
     BOOST_CHECK_EQUAL(addrman.size(), 1U);
 
     // Add three addresses to new table.
-    CService addr2 = ResolveService("250.3.1.1", 8333);
+    CService addr2 = ResolveService("250.3.1.1", 10605);
     CService addr3 = ResolveService("250.3.2.2", 9999);
     CService addr4 = ResolveService("250.3.3.3", 9999);
 
     BOOST_CHECK(addrman.Add(CAddress(addr2, NODE_NONE),
-                            ResolveService("250.3.1.1", 8333)));
+                            ResolveService("250.3.1.1", 10605)));
     BOOST_CHECK(addrman.Add(CAddress(addr3, NODE_NONE),
-                            ResolveService("250.3.1.1", 8333)));
+                            ResolveService("250.3.1.1", 10605)));
     BOOST_CHECK(addrman.Add(CAddress(addr4, NODE_NONE),
-                            ResolveService("250.4.1.1", 8333)));
+                            ResolveService("250.4.1.1", 10605)));
 
     // Add three addresses to tried table.
-    CService addr5 = ResolveService("250.4.4.4", 8333);
+    CService addr5 = ResolveService("250.4.4.4", 10605);
     CService addr6 = ResolveService("250.4.5.5", 7777);
-    CService addr7 = ResolveService("250.4.6.6", 8333);
+    CService addr7 = ResolveService("250.4.6.6", 10605);
 
     BOOST_CHECK(addrman.Add(CAddress(addr5, NODE_NONE),
-                            ResolveService("250.3.1.1", 8333)));
+                            ResolveService("250.3.1.1", 10605)));
     addrman.Good(CAddress(addr5, NODE_NONE));
     BOOST_CHECK(addrman.Add(CAddress(addr6, NODE_NONE),
-                            ResolveService("250.3.1.1", 8333)));
+                            ResolveService("250.3.1.1", 10605)));
     addrman.Good(CAddress(addr6, NODE_NONE));
     BOOST_CHECK(addrman.Add(CAddress(addr7, NODE_NONE),
-                            ResolveService("250.1.1.3", 8333)));
+                            ResolveService("250.1.1.3", 10605)));
     addrman.Good(CAddress(addr7, NODE_NONE));
 
     // Test: 6 addrs + 1 addr from last test = 7.
@@ -308,9 +308,9 @@ BOOST_AUTO_TEST_CASE(addrman_find) {
 
     BOOST_CHECK_EQUAL(addrman.size(), 0U);
 
-    CAddress addr1 = CAddress(ResolveService("250.1.2.1", 8333), NODE_NONE);
+    CAddress addr1 = CAddress(ResolveService("250.1.2.1", 10605), NODE_NONE);
     CAddress addr2 = CAddress(ResolveService("250.1.2.1", 9999), NODE_NONE);
-    CAddress addr3 = CAddress(ResolveService("251.255.2.1", 8333), NODE_NONE);
+    CAddress addr3 = CAddress(ResolveService("251.255.2.1", 10605), NODE_NONE);
 
     CNetAddr source1 = ResolveIP("250.1.2.1");
     CNetAddr source2 = ResolveIP("250.1.2.2");
@@ -322,7 +322,7 @@ BOOST_AUTO_TEST_CASE(addrman_find) {
     // Test: ensure Find returns an IP matching what we searched on.
     CAddrInfo *info1 = addrman.Find(addr1);
     BOOST_REQUIRE(info1);
-    BOOST_CHECK_EQUAL(info1->ToString(), "250.1.2.1:8333");
+    BOOST_CHECK_EQUAL(info1->ToString(), "250.1.2.1:10605");
 
     // Test: Find does not discriminate by port number.
     CAddrInfo *info2 = addrman.Find(addr2);
@@ -332,7 +332,7 @@ BOOST_AUTO_TEST_CASE(addrman_find) {
     // Test: Find returns another IP matching what we searched on.
     CAddrInfo *info3 = addrman.Find(addr3);
     BOOST_REQUIRE(info3);
-    BOOST_CHECK_EQUAL(info3->ToString(), "251.255.2.1:8333");
+    BOOST_CHECK_EQUAL(info3->ToString(), "251.255.2.1:10605");
 }
 
 BOOST_AUTO_TEST_CASE(addrman_create) {
@@ -340,17 +340,17 @@ BOOST_AUTO_TEST_CASE(addrman_create) {
 
     BOOST_CHECK_EQUAL(addrman.size(), 0U);
 
-    CAddress addr1 = CAddress(ResolveService("250.1.2.1", 8333), NODE_NONE);
+    CAddress addr1 = CAddress(ResolveService("250.1.2.1", 10605), NODE_NONE);
     CNetAddr source1 = ResolveIP("250.1.2.1");
 
     int nId;
     CAddrInfo *pinfo = addrman.Create(addr1, source1, &nId);
 
     // Test: The result should be the same as the input addr.
-    BOOST_CHECK_EQUAL(pinfo->ToString(), "250.1.2.1:8333");
+    BOOST_CHECK_EQUAL(pinfo->ToString(), "250.1.2.1:10605");
 
     CAddrInfo *info2 = addrman.Find(addr1);
-    BOOST_CHECK_EQUAL(info2->ToString(), "250.1.2.1:8333");
+    BOOST_CHECK_EQUAL(info2->ToString(), "250.1.2.1:10605");
 }
 
 BOOST_AUTO_TEST_CASE(addrman_delete) {
@@ -358,7 +358,7 @@ BOOST_AUTO_TEST_CASE(addrman_delete) {
 
     BOOST_CHECK_EQUAL(addrman.size(), 0U);
 
-    CAddress addr1 = CAddress(ResolveService("250.1.2.1", 8333), NODE_NONE);
+    CAddress addr1 = CAddress(ResolveService("250.1.2.1", 10605), NODE_NONE);
     CNetAddr source1 = ResolveIP("250.1.2.1");
 
     int nId;
@@ -381,15 +381,15 @@ BOOST_AUTO_TEST_CASE(addrman_getaddr) {
     std::vector<CAddress> vAddr1 = addrman.GetAddr();
     BOOST_CHECK_EQUAL(vAddr1.size(), 0U);
 
-    CAddress addr1 = CAddress(ResolveService("250.250.2.1", 8333), NODE_NONE);
+    CAddress addr1 = CAddress(ResolveService("250.250.2.1", 10605), NODE_NONE);
     addr1.nTime = GetAdjustedTime(); // Set time so isTerrible = false
     CAddress addr2 = CAddress(ResolveService("250.251.2.2", 9999), NODE_NONE);
     addr2.nTime = GetAdjustedTime();
-    CAddress addr3 = CAddress(ResolveService("251.252.2.3", 8333), NODE_NONE);
+    CAddress addr3 = CAddress(ResolveService("251.252.2.3", 10605), NODE_NONE);
     addr3.nTime = GetAdjustedTime();
-    CAddress addr4 = CAddress(ResolveService("252.253.3.4", 8333), NODE_NONE);
+    CAddress addr4 = CAddress(ResolveService("252.253.3.4", 10605), NODE_NONE);
     addr4.nTime = GetAdjustedTime();
-    CAddress addr5 = CAddress(ResolveService("252.254.4.5", 8333), NODE_NONE);
+    CAddress addr5 = CAddress(ResolveService("252.254.4.5", 10605), NODE_NONE);
     addr5.nTime = GetAdjustedTime();
     CNetAddr source1 = ResolveIP("250.1.2.1");
     CNetAddr source2 = ResolveIP("250.2.3.3");
@@ -436,7 +436,7 @@ BOOST_AUTO_TEST_CASE(addrman_getaddr) {
 BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket_legacy) {
     CAddrManTest addrman;
 
-    CAddress addr1 = CAddress(ResolveService("250.1.1.1", 8333), NODE_NONE);
+    CAddress addr1 = CAddress(ResolveService("250.1.1.1", 10605), NODE_NONE);
     CAddress addr2 = CAddress(ResolveService("250.1.1.1", 9999), NODE_NONE);
 
     CNetAddr source1 = ResolveIP("250.1.1.1");
@@ -449,6 +449,8 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket_legacy) {
     // use /16
     std::vector<bool> asmap;
 
+    // This asserts that the above address falls into a specific bucket.
+    // It is probably test overfitting, but it is left here for now.
     BOOST_CHECK_EQUAL(info1.GetTriedBucket(nKey1, asmap), 40);
 
     // Test: Make sure key actually randomizes bucket placement. A fail on
@@ -492,7 +494,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket_legacy) {
 BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket_legacy) {
     CAddrManTest addrman;
 
-    CAddress addr1 = CAddress(ResolveService("250.1.2.1", 8333), NODE_NONE);
+    CAddress addr1 = CAddress(ResolveService("250.1.2.1", 10605), NODE_NONE);
     CAddress addr2 = CAddress(ResolveService("250.1.2.1", 9999), NODE_NONE);
 
     CNetAddr source1 = ResolveIP("250.1.2.1");
@@ -573,7 +575,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket_legacy) {
 BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket) {
     CAddrManTest addrman;
 
-    CAddress addr1 = CAddress(ResolveService("250.1.1.1", 8333), NODE_NONE);
+    CAddress addr1 = CAddress(ResolveService("250.1.1.1", 10605), NODE_NONE);
     CAddress addr2 = CAddress(ResolveService("250.1.1.1", 9999), NODE_NONE);
 
     CNetAddr source1 = ResolveIP("250.1.1.1");
@@ -585,6 +587,8 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket) {
 
     std::vector<bool> asmap = FromBytes(asmap_raw, sizeof(asmap_raw) * 8);
 
+    // This asserts that the above address falls into a specific bucket.
+    // It is probably test overfitting, but it is left here for now.
     BOOST_CHECK_EQUAL(info1.GetTriedBucket(nKey1, asmap), 236);
 
     // Test: Make sure key actually randomizes bucket placement. A fail on
@@ -628,7 +632,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket) {
 BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket) {
     CAddrManTest addrman;
 
-    CAddress addr1 = CAddress(ResolveService("250.1.2.1", 8333), NODE_NONE);
+    CAddress addr1 = CAddress(ResolveService("250.1.2.1", 10605), NODE_NONE);
     CAddress addr2 = CAddress(ResolveService("250.1.2.1", 9999), NODE_NONE);
 
     CNetAddr source1 = ResolveIP("250.1.2.1");

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(caddrdb_read) {
     addrmanUncorrupted.MakeDeterministic();
 
     CService addr1, addr2, addr3;
-    BOOST_CHECK(Lookup("250.7.1.1", addr1, 8333, false));
+    BOOST_CHECK(Lookup("250.7.1.1", addr1, 10605, false));
     BOOST_CHECK(Lookup("250.7.2.2", addr2, 9999, false));
     BOOST_CHECK(Lookup("250.7.3.3", addr3, 9999, false));
     BOOST_CHECK(Lookup(std::string("250.7.3.3", 9), addr3, 9999, false));
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(caddrdb_read) {
 
     // Add three addresses to new table.
     CService source;
-    BOOST_CHECK(Lookup("252.5.1.1", source, 8333, false));
+    BOOST_CHECK(Lookup("252.5.1.1", source, 10605, false));
     BOOST_CHECK(addrmanUncorrupted.Add(CAddress(addr1, NODE_NONE), source));
     BOOST_CHECK(addrmanUncorrupted.Add(CAddress(addr2, NODE_NONE), source));
     BOOST_CHECK(addrmanUncorrupted.Add(CAddress(addr3, NODE_NONE), source));

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -91,16 +91,16 @@ BOOST_AUTO_TEST_CASE(netbase_splithost) {
     BOOST_CHECK(TestSplitHost("www.bitcoin.org:80", "www.bitcoin.org", 80));
     BOOST_CHECK(TestSplitHost("[www.bitcoin.org]:80", "www.bitcoin.org", 80));
     BOOST_CHECK(TestSplitHost("127.0.0.1", "127.0.0.1", -1));
-    BOOST_CHECK(TestSplitHost("127.0.0.1:8333", "127.0.0.1", 8333));
+    BOOST_CHECK(TestSplitHost("127.0.0.1:10605", "127.0.0.1", 10605));
     BOOST_CHECK(TestSplitHost("[127.0.0.1]", "127.0.0.1", -1));
-    BOOST_CHECK(TestSplitHost("[127.0.0.1]:8333", "127.0.0.1", 8333));
+    BOOST_CHECK(TestSplitHost("[127.0.0.1]:10605", "127.0.0.1", 10605));
     BOOST_CHECK(TestSplitHost("::ffff:127.0.0.1", "::ffff:127.0.0.1", -1));
     BOOST_CHECK(
-        TestSplitHost("[::ffff:127.0.0.1]:8333", "::ffff:127.0.0.1", 8333));
-    BOOST_CHECK(TestSplitHost("[::]:8333", "::", 8333));
-    BOOST_CHECK(TestSplitHost("::8333", "::8333", -1));
-    BOOST_CHECK(TestSplitHost(":8333", "", 8333));
-    BOOST_CHECK(TestSplitHost("[]:8333", "", 8333));
+        TestSplitHost("[::ffff:127.0.0.1]:10605", "::ffff:127.0.0.1", 10605));
+    BOOST_CHECK(TestSplitHost("[::]:10605", "::", 10605));
+    BOOST_CHECK(TestSplitHost("::10605", "::10605", -1));
+    BOOST_CHECK(TestSplitHost(":10605", "", 10605));
+    BOOST_CHECK(TestSplitHost("[]:10605", "", 10605));
     BOOST_CHECK(TestSplitHost("", "", -1));
 }
 
@@ -111,10 +111,10 @@ static bool TestParse(std::string src, std::string canon) {
 
 BOOST_AUTO_TEST_CASE(netbase_lookupnumeric) {
     BOOST_CHECK(TestParse("127.0.0.1", "127.0.0.1:65535"));
-    BOOST_CHECK(TestParse("127.0.0.1:8333", "127.0.0.1:8333"));
+    BOOST_CHECK(TestParse("127.0.0.1:10605", "127.0.0.1:10605"));
     BOOST_CHECK(TestParse("::ffff:127.0.0.1", "127.0.0.1:65535"));
     BOOST_CHECK(TestParse("::", "[::]:65535"));
-    BOOST_CHECK(TestParse("[::]:8333", "[::]:8333"));
+    BOOST_CHECK(TestParse("[::]:10605", "[::]:10605"));
     BOOST_CHECK(TestParse("[127.0.0.1]", "127.0.0.1:65535"));
     BOOST_CHECK(TestParse(":::", "[::]:0"));
 

--- a/test/functional/feature_proxy.py
+++ b/test/functional/feature_proxy.py
@@ -140,24 +140,24 @@ class ProxyTest(BitcoinTestFramework):
 
         if test_onion:
             # Test: outgoing onion connection through node
-            node.addnode("bitcoinostk4e4re.onion:8333", "onetry")
+            node.addnode("bitcoinostk4e4re.onion:10605", "onetry")
             cmd = proxies[2].queue.get()
             assert isinstance(cmd, Socks5Command)
             assert_equal(cmd.atyp, AddressType.DOMAINNAME)
             assert_equal(cmd.addr, b"bitcoinostk4e4re.onion")
-            assert_equal(cmd.port, 8333)
+            assert_equal(cmd.port, 10605)
             if not auth:
                 assert_equal(cmd.username, None)
                 assert_equal(cmd.password, None)
             rv.append(cmd)
 
         # Test: outgoing DNS name connection through node
-        node.addnode("node.noumenon:8333", "onetry")
+        node.addnode("node.noumenon:10605", "onetry")
         cmd = proxies[3].queue.get()
         assert isinstance(cmd, Socks5Command)
         assert_equal(cmd.atyp, AddressType.DOMAINNAME)
         assert_equal(cmd.addr, b"node.noumenon")
-        assert_equal(cmd.port, 8333)
+        assert_equal(cmd.port, 10605)
         if not auth:
             assert_equal(cmd.username, None)
             assert_equal(cmd.password, None)

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -64,7 +64,7 @@ class ZMQTest (BitcoinTestFramework):
         # Invalid zmq arguments don't take down the node, see #17185.
         self.restart_node(0, ["-zmqpubrawtx=foo", "-zmqpubhashtx=bar"])
 
-        address = 'tcp://127.0.0.1:28332'
+        address = 'tcp://127.0.0.1:13604'
         sockets = []
         subs = []
         services = [b"hashblock", b"hashtx", b"rawblock", b"rawtx"]

--- a/test/functional/p2p_addr_relay.py
+++ b/test/functional/p2p_addr_relay.py
@@ -26,7 +26,7 @@ for i in range(10):
     addr.time = int(time.time()) + i
     addr.nServices = NODE_NETWORK
     addr.ip = "123.123.123.{}".format(i % 256)
-    addr.port = 8333 + i
+    addr.port = 10605 + i
     ADDRS.append(addr)
 
 
@@ -35,7 +35,7 @@ class AddrReceiver(P2PInterface):
         for addr in message.addrs:
             assert_equal(addr.nServices, NODE_NETWORK)
             assert addr.ip.startswith('123.123.123.')
-            assert (8333 <= addr.port < 8343)
+            assert (10605 <= addr.port < 10615)
 
 
 class AddrTest(BitcoinTestFramework):

--- a/test/functional/p2p_addrv2_relay.py
+++ b/test/functional/p2p_addrv2_relay.py
@@ -23,7 +23,7 @@ for i in range(10):
     addr.time = int(time.time()) + i
     addr.nServices = NODE_NETWORK
     addr.ip = "123.123.123.{}".format(i % 256)
-    addr.port = 8333 + i
+    addr.port = 10605 + i
     ADDRS.append(addr)
 
 
@@ -37,7 +37,7 @@ class AddrReceiver(P2PInterface):
         for addr in message.addrs:
             assert_equal(addr.nServices, NODE_NETWORK)
             assert addr.ip.startswith('123.123.123.')
-            assert (8333 <= addr.port < 8343)
+            assert (10605 <= addr.port < 10615)
         self.addrv2_received_and_checked = True
 
     def wait_for_addrv2(self):

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -206,7 +206,7 @@ class NetTest(BitcoinTestFramework):
             addr.time = 100000000
             addr.nServices = NODE_NETWORK
             addr.ip = a
-            addr.port = 8333
+            addr.port = 10605
             msg.addrs.append(addr)
         self.nodes[0].p2p.send_and_ping(msg)
 
@@ -218,7 +218,7 @@ class NetTest(BitcoinTestFramework):
             assert_greater_than(a["time"], 1527811200)  # 1st June 2018
             assert_equal(a["services"], NODE_NETWORK)
             assert a["address"] in imported_addrs
-            assert_equal(a["port"], 8333)
+            assert_equal(a["port"], 10605)
 
         assert_raises_rpc_error(-8, "Address count out of range",
                                 self.nodes[0].getnodeaddresses, -1)

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -283,7 +283,7 @@ def wait_until(predicate, *, attempts=float('inf'),
 
 # The maximum number of nodes a single test can spawn
 MAX_NODES = 12
-# Don't assign rpc or p2p ports lower than this (for example: 18333 is the
+# Don't assign rpc or p2p ports lower than this (for example: 11605 is the
 # default testnet port)
 PORT_MIN = int(os.getenv('TEST_RUNNER_PORT_MIN', default=20000))
 # The number of ports to "reserve" for p2p and rpc, each


### PR DESCRIPTION
Since Lotus is not a ledger fork, there is no reason to maintain the
same default ports. In fact, this makes it harder for individuals to run
nodes on the same server as whatever of flavor of bitcoind they prefer.
This we're going to move to a different port to support ease of use for
node operators.

New ports:
* mainnet
  * p2p - 10605
  * rpc - 10604
* testnet
  * p2p - 11605
  * rpc - 11604
* regtest
  * p2p - 12605
  * rpc - 12604


Closes #153