### PR TITLE
Fix getblocktemplate for testnet

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -47,6 +47,11 @@ int64_t UpdateTime(CBlockHeader *pblock, const CChainParams &chainParams,
     return nNewTime - nOldTime;
 }
 
+Amount GetBlockRewardFromFees(Amount nFees) {
+    // 50% of fees get burned.
+    return nFees / 2;
+}
+
 uint64_t CTxMemPoolModifiedEntry::GetVirtualSizeWithAncestors() const {
     return GetVirtualTransactionSize(nSizeWithAncestors,
                                      nSigOpCountWithAncestors);
@@ -185,8 +190,7 @@ BlockAssembler::CreateNewBlock(const CScript &scriptPubKeyIn) {
     }
 
     int64_t nTime1 = GetTimeMicros();
-    // 50% of fees get burned.
-    const Amount amountFeeReward = nFees / 2;
+    const Amount amountFeeReward = GetBlockRewardFromFees(nFees);
 
     m_last_block_num_txs = nBlockTx;
     m_last_block_size = nBlockSize;

--- a/src/miner.h
+++ b/src/miner.h
@@ -66,6 +66,12 @@ struct CTxMemPoolModifiedEntry {
 };
 
 /**
+ * Calculate the additional block reward in the coinbase from fees.
+ * Currenty, 50% of fees are burned.
+ */
+Amount GetBlockRewardFromFees(Amount nFees);
+
+/**
  * Comparator for CTxMemPool::txiter objects.
  * It simply compares the internal memory address of the CTxMemPoolEntry object
  * pointed to. This means it has no meaning, and is only useful for using them


### PR DESCRIPTION
This fixes a bug where when the testnet resets the nBits to 0x1c100000, the coinbase outputs would remain unchanged, resulting in invalid blocks.