### PR TITLE
Implement raw encoding and decoding on XAddress format

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -459,6 +459,7 @@ add_library(common
 	bloom.cpp
 	cashaddr.cpp
 	cashaddrenc.cpp
+	addresses/xaddress.cpp
 	chainparams.cpp
 	config.cpp
 	consensus/merkle.cpp

--- a/src/addresses/xaddress.cpp
+++ b/src/addresses/xaddress.cpp
@@ -1,0 +1,99 @@
+// Copyright (c) 2021 Logos Foundation
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <addresses/xaddress.h>
+#include <base58.h>
+#include <hash.h>
+#include <uint256.h>
+#include <util/strencodings.h>
+#include <util/string.h>
+#include <util/vector.h>
+
+#include <boost/utility/string_ref.hpp>
+#include <string>
+
+namespace XAddress {
+/**
+ * Create a checksum.
+ */
+std::string CreateCheck(const boost::string_ref addressWithoutCheck) {
+    uint256 hash = Hash(addressWithoutCheck);
+    std::vector<uint8_t> vch(hash.begin(), hash.begin() + 4);
+    std::string unpaddedCheck = EncodeBase58(vch);
+    const size_t padding = 6 - unpaddedCheck.length();
+    return std::string(padding, '1').append(unpaddedCheck);
+}
+
+/**
+ * Encode a XAddress string.
+ */
+std::string Encode(const std::string &token, const uint8_t network,
+                   const std::vector<uint8_t> &payload) {
+    const std::string encodedPayload = EncodeBase58(payload);
+    std::string address;
+    address.append(token);
+    address.append(1, network);
+    address.append(encodedPayload);
+    address.append(CreateCheck(address));
+    return address;
+}
+
+/**
+ * Check integrity of an XAddress
+ */
+bool IntegrityCheck(const boost::string_ref address) {
+    if (address.length() < 6) {
+        return false;
+    }
+    std::vector<uint8_t> decodedCheck;
+    const std::string encodedCheck(address.substr(address.length() - 6, 6));
+    if (!DecodeBase58(encodedCheck, decodedCheck, 6)) {
+        return false;
+    }
+    if (decodedCheck.size() < 4) {
+        return false;
+    }
+    const uint256 check = Hash(address.substr(0, address.length() - 6));
+    // decodedCheck potentially has excess padding due to the way
+    // base58 decode processes padding and bytes.
+    if (memcmp(&check, &decodedCheck[decodedCheck.size() - 4], 4)) {
+        return false;
+    }
+    return true;
+}
+
+/**
+ * Decode a XAddress string.
+ */
+bool Decode(const boost::string_ref address, Content &parsedOutput) {
+    if (!IntegrityCheck(address)) {
+        return false;
+    }
+    const boost::string_ref addressWithoutCheck =
+        address.substr(0, address.length() - 6);
+    const auto networkPosition =
+        std::find_if(addressWithoutCheck.begin(), addressWithoutCheck.end(),
+                     [](const char c) -> bool {
+                         return std::isupper(c) || std::isdigit(c) || c == '_';
+                     });
+    if (networkPosition == addressWithoutCheck.end()) {
+        return false;
+    }
+    const boost::string_ref token = addressWithoutCheck.substr(
+        0, std::distance(addressWithoutCheck.begin(), networkPosition));
+    const uint8_t networkByte = uint8_t(*networkPosition);
+    // Need to be able to get a c_str() from this, so we must do a copy.
+    const std::string encodedPayload(networkPosition + 1,
+                                     addressWithoutCheck.end());
+    // vch length cannot be greater than encodedPayload
+    std::vector<uint8_t> vch;
+    if (!DecodeBase58(encodedPayload, vch, encodedPayload.length())) {
+        return false;
+    }
+    parsedOutput =
+        Content(std::string(token.begin(), token.end()), networkByte, vch);
+    return true;
+}
+
+} // namespace XAddress

--- a/src/addresses/xaddress.cpp
+++ b/src/addresses/xaddress.cpp
@@ -18,10 +18,10 @@ namespace XAddress {
  */
 uint256 HashAddressContents(const Content &addressContent) {
     CHashWriter hasher(SER_GETHASH, 0);
-    hasher << addressContent.token;
-    hasher << uint8_t(addressContent.network);
-    hasher << uint8_t(addressContent.type);
-    hasher << addressContent.payload;
+    hasher << addressContent.m_token;
+    hasher << uint8_t(addressContent.m_network);
+    hasher << uint8_t(addressContent.m_type);
+    hasher << addressContent.m_payload;
     return hasher.GetSHA256();
 }
 
@@ -31,16 +31,16 @@ uint256 HashAddressContents(const Content &addressContent) {
 std::string Encode(const Content &addressContent) {
     std::vector<uint8_t> preencodedBuffer;
     uint256 check = HashAddressContents(addressContent);
-    preencodedBuffer.reserve(addressContent.payload.size() + 5);
-    preencodedBuffer.push_back(addressContent.type);
+    preencodedBuffer.reserve(addressContent.m_payload.size() + 5);
+    preencodedBuffer.push_back(addressContent.m_type);
     preencodedBuffer.insert(preencodedBuffer.end(),
-                            addressContent.payload.begin(),
-                            addressContent.payload.end());
+                            addressContent.m_payload.begin(),
+                            addressContent.m_payload.end());
     preencodedBuffer.insert(preencodedBuffer.end(), check.begin(),
                             check.begin() + 4);
     std::string address;
-    address.append(addressContent.token);
-    address.append(1, addressContent.network);
+    address.append(addressContent.m_token);
+    address.append(1, addressContent.m_network);
     address.append(EncodeBase58(preencodedBuffer));
     return address;
 }

--- a/src/addresses/xaddress.h
+++ b/src/addresses/xaddress.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2021 Logos Foundation
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_XADDR_H
+#define BITCOIN_XADDR_H
+
+#include <boost/utility/string_ref.hpp>
+#include <string>
+#include <vector>
+
+namespace XAddress {
+
+class Content {
+public:
+    std::string token;
+    uint8_t network;
+    std::vector<uint8_t> payload;
+
+    Content() = default;
+
+    Content(std::string _token, uint8_t _network, std::vector<uint8_t> _payload)
+        : token(_token), network(_network), payload(_payload) {}
+};
+
+/**
+ * Encode an XAddress string.
+ */
+std::string Encode(const std::string &token, const uint8_t network,
+                   const std::vector<uint8_t> &payload);
+/**
+ * Decode an XAddress string. Returns false on failure, and parsedOutput is not
+ * modified.
+ */
+bool Decode(boost::string_ref address, Content &parsedOutput);
+} // namespace XAddress
+
+#endif // BITCOIN_XADDR_H

--- a/src/addresses/xaddress.h
+++ b/src/addresses/xaddress.h
@@ -5,34 +5,46 @@
 #ifndef BITCOIN_XADDR_H
 #define BITCOIN_XADDR_H
 
-#include <boost/utility/string_ref.hpp>
 #include <string>
 #include <vector>
 
 namespace XAddress {
 
+const std::string TOKEN_NAME = "lotus";
+
+enum NetworkType : uint8_t {
+    MAINNET = '_',
+    TESTNET = 'T',
+    REGTEST = 'R',
+};
+
+enum AddressType : uint8_t {
+    SCRIPT_PUB_KEY = 0,
+};
+
 class Content {
 public:
     std::string token;
-    uint8_t network;
+    NetworkType network;
+    AddressType type;
     std::vector<uint8_t> payload;
 
     Content() = default;
 
-    Content(std::string _token, uint8_t _network, std::vector<uint8_t> _payload)
-        : token(_token), network(_network), payload(_payload) {}
+    Content(std::string _token, NetworkType _network, AddressType _type,
+            std::vector<uint8_t> _payload)
+        : token(_token), network(_network), type(_type), payload(_payload) {}
 };
 
 /**
  * Encode an XAddress string.
  */
-std::string Encode(const std::string &token, const uint8_t network,
-                   const std::vector<uint8_t> &payload);
+std::string Encode(const Content &addressContent);
 /**
  * Decode an XAddress string. Returns false on failure, and parsedOutput is not
  * modified.
  */
-bool Decode(boost::string_ref address, Content &parsedOutput);
+bool Decode(const std::string &address, Content &parsedOutput);
 } // namespace XAddress
 
 #endif // BITCOIN_XADDR_H

--- a/src/addresses/xaddress.h
+++ b/src/addresses/xaddress.h
@@ -22,6 +22,14 @@ enum AddressType : uint8_t {
     SCRIPT_PUB_KEY = 0,
 };
 
+enum DecodeError : uint8_t {
+    DECODE_OK = 0,
+    NO_NETWORK_POSITION = 1,
+    BASE58_DECODE_FAILED = 2,
+    UNDERSIZED_PAYLOAD = 3,
+    INTEGRITY_CHECK_FAILED = 4,
+};
+
 class Content {
 public:
     std::string token;
@@ -44,7 +52,7 @@ std::string Encode(const Content &addressContent);
  * Decode an XAddress string. Returns false on failure, and parsedOutput is not
  * modified.
  */
-bool Decode(const std::string &address, Content &parsedOutput);
+DecodeError Decode(const std::string &address, Content &parsedOutput);
 } // namespace XAddress
 
 #endif // BITCOIN_XADDR_H

--- a/src/addresses/xaddress.h
+++ b/src/addresses/xaddress.h
@@ -32,16 +32,17 @@ enum DecodeError : uint8_t {
 
 class Content {
 public:
-    std::string token;
-    NetworkType network;
-    AddressType type;
-    std::vector<uint8_t> payload;
+    std::string m_token;
+    NetworkType m_network;
+    AddressType m_type;
+    std::vector<uint8_t> m_payload;
 
     Content() = default;
 
-    Content(std::string _token, NetworkType _network, AddressType _type,
-            std::vector<uint8_t> _payload)
-        : token(_token), network(_network), type(_type), payload(_payload) {}
+    Content(std::string token, NetworkType network, AddressType type,
+            std::vector<uint8_t> payload)
+        : m_token(token), m_network(network), m_type(type), m_payload(payload) {
+    }
 };
 
 /**

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -138,6 +138,7 @@ add_boost_unit_tests_to_suite(bitcoin test_lotus
 		bswap_tests.cpp
 		cashaddr_tests.cpp
 		cashaddrenc_tests.cpp
+		xaddress_tests.cpp
 		checkdatasig_tests.cpp
 		checkpoints_tests.cpp
 		checkqueue_tests.cpp

--- a/src/test/xaddress_tests.cpp
+++ b/src/test/xaddress_tests.cpp
@@ -37,11 +37,11 @@ BOOST_AUTO_TEST_CASE(raw_encode_decode_succeeds) {
         XAddress::Content parsedAddress;
         BOOST_CHECK_EQUAL(XAddress::Decode(encodedAddress, parsedAddress),
                           XAddress::DECODE_OK);
-        BOOST_CHECK_EQUAL(parsedAddress.token, XAddress::TOKEN_NAME);
-        BOOST_CHECK_MESSAGE(parsedAddress.network == XAddress::MAINNET,
+        BOOST_CHECK_EQUAL(parsedAddress.m_token, XAddress::TOKEN_NAME);
+        BOOST_CHECK_MESSAGE(parsedAddress.m_network == XAddress::MAINNET,
                             "Network byte incorrect");
-        BOOST_CHECK_EQUAL(parsedAddress.type, XAddress::SCRIPT_PUB_KEY);
-        BOOST_CHECK_MESSAGE(parsedAddress.payload == payload,
+        BOOST_CHECK_EQUAL(parsedAddress.m_type, XAddress::SCRIPT_PUB_KEY);
+        BOOST_CHECK_MESSAGE(parsedAddress.m_payload == payload,
                             "Parsed payload incorrect");
     }
 }

--- a/src/test/xaddress_tests.cpp
+++ b/src/test/xaddress_tests.cpp
@@ -1,0 +1,79 @@
+// Copyright (c) 2021 Logos Foundation
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <addresses/xaddress.h>
+#include <random.h>
+#include <test/util/setup_common.h>
+#include <util/strencodings.h>
+#include <util/vector.h>
+
+#include <algorithm>
+#include <boost/test/unit_test.hpp>
+#include <functional>
+#include <iostream>
+#include <random>
+#include <string>
+
+/** All alphanumeric characters except for "0", "I", "O", and "l" */
+const std::string pszBase58 =
+    "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+BOOST_FIXTURE_TEST_SUITE(xaddress_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(raw_encode_decode_succeeds) {
+    // First create an instance of an engine.
+    std::random_device rnd_device;
+    // Specify the engine and distribution.
+    std::mt19937 mersenne_engine{rnd_device()}; // Generates random integers
+    std::uniform_int_distribution<uint8_t> dist{0, 255};
+
+    auto gen = [&dist, &mersenne_engine]() { return dist(mersenne_engine); };
+
+    // Assert that encode/decode works.
+    for (size_t i = 0; i < 10000; i++) {
+        std::vector<uint8_t> payload(10);
+        std::generate(begin(payload), end(payload), gen);
+        const std::string encodedAddress =
+            XAddress::Encode("lotus", '_', payload);
+        XAddress::Content parsedAddress;
+        BOOST_CHECK_EQUAL(XAddress::Decode(encodedAddress, parsedAddress),
+                          true);
+        BOOST_CHECK_EQUAL(parsedAddress.token, "lotus");
+        BOOST_CHECK_MESSAGE(parsedAddress.network == uint8_t('_'),
+                            "Network byte incorrect");
+        BOOST_CHECK_MESSAGE(parsedAddress.payload == payload,
+                            "Parsed payload incorrect");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(raw_encode_decode_fails) {
+    // First create an instance of an engine.
+    std::random_device rnd_device;
+    // Specify the engine and distribution.
+    std::mt19937 mersenne_engine{rnd_device()}; // Generates random integers
+    std::uniform_int_distribution<uint8_t> dist{0, 255};
+
+    auto gen = [&dist, &mersenne_engine]() { return dist(mersenne_engine); };
+
+    FastRandomContext randContext;
+
+    // Assert that check fails.
+    for (size_t i = 0; i < 10000; i++) {
+        std::vector<uint8_t> payload(10);
+        std::generate(begin(payload), end(payload), gen);
+        std::string encodedAddress = XAddress::Encode("lotus", 'T', payload);
+        const size_t mutatedPosition =
+            randContext.randrange(encodedAddress.size());
+        const unsigned char replacedCharacter =
+            pszBase58[randContext.randrange(pszBase58.size())];
+        const bool isValid =
+            encodedAddress[mutatedPosition] == replacedCharacter;
+        encodedAddress[mutatedPosition] = replacedCharacter;
+        XAddress::Content parsedAddress;
+        BOOST_CHECK_EQUAL(XAddress::Decode(encodedAddress, parsedAddress),
+                          isValid);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/xaddress_tests.cpp
+++ b/src/test/xaddress_tests.cpp
@@ -24,8 +24,7 @@ BOOST_FIXTURE_TEST_SUITE(xaddress_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(raw_encode_decode_succeeds) {
     std::random_device rd;
-    auto lcg = MMIXLinearCongruentialGenerator(rd());
-    auto gen = [&lcg]() { return uint8_t(lcg.next()); };
+    auto gen = [&rd]() { return uint8_t(rd()); };
 
     // Assert that encode/decode works.
     for (size_t i = 0; i < 10000; i++) {
@@ -48,9 +47,7 @@ BOOST_AUTO_TEST_CASE(raw_encode_decode_succeeds) {
 
 BOOST_AUTO_TEST_CASE(raw_encode_decode_fails) {
     std::random_device rd;
-    auto lcg = MMIXLinearCongruentialGenerator(rd());
-    auto gen = [&lcg]() { return uint8_t(lcg.next()); };
-    FastRandomContext randContext;
+    auto gen = [&rd]() { return uint8_t(rd()); };
 
     // Assert that we get some XAddress::BASE58_DECODE_FAILED or
     // XAddress::INTEGRITY_CHECK_FAILED failures.
@@ -60,10 +57,8 @@ BOOST_AUTO_TEST_CASE(raw_encode_decode_fails) {
         std::string encodedAddress = XAddress::Encode(
             XAddress::Content(XAddress::TOKEN_NAME, XAddress::MAINNET,
                               XAddress::SCRIPT_PUB_KEY, payload));
-        const size_t mutatedPosition =
-            randContext.randrange(encodedAddress.size());
-        const unsigned char replacedCharacter =
-            pszBase58[randContext.randrange(pszBase58.size())];
+        const size_t mutatedPosition = rd() % encodedAddress.size();
+        const unsigned char replacedCharacter = rd() % pszBase58.size();
         const auto error = encodedAddress[mutatedPosition] == replacedCharacter
                                ? XAddress::DECODE_OK
                                : XAddress::BASE58_DECODE_FAILED |

--- a/src/test/xaddress_tests.cpp
+++ b/src/test/xaddress_tests.cpp
@@ -8,6 +8,8 @@
 #include <util/strencodings.h>
 #include <util/vector.h>
 
+#include <test/lcg.h>
+
 #include <algorithm>
 #include <boost/test/unit_test.hpp>
 #include <functional>
@@ -21,13 +23,9 @@ const std::string pszBase58 =
 BOOST_FIXTURE_TEST_SUITE(xaddress_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(raw_encode_decode_succeeds) {
-    // First create an instance of an engine.
-    std::random_device rnd_device;
-    // Specify the engine and distribution.
-    std::mt19937 mersenne_engine{rnd_device()}; // Generates random integers
-    std::uniform_int_distribution<uint8_t> dist{0, 255};
-
-    auto gen = [&dist, &mersenne_engine]() { return dist(mersenne_engine); };
+    std::random_device rd;
+    auto lcg = MMIXLinearCongruentialGenerator(rd());
+    auto gen = [&lcg]() { return uint8_t(lcg.next()); };
 
     // Assert that encode/decode works.
     for (size_t i = 0; i < 10000; i++) {
@@ -38,7 +36,7 @@ BOOST_AUTO_TEST_CASE(raw_encode_decode_succeeds) {
                               XAddress::SCRIPT_PUB_KEY, payload));
         XAddress::Content parsedAddress;
         BOOST_CHECK_EQUAL(XAddress::Decode(encodedAddress, parsedAddress),
-                          true);
+                          XAddress::DECODE_OK);
         BOOST_CHECK_EQUAL(parsedAddress.token, XAddress::TOKEN_NAME);
         BOOST_CHECK_MESSAGE(parsedAddress.network == XAddress::MAINNET,
                             "Network byte incorrect");
@@ -49,18 +47,14 @@ BOOST_AUTO_TEST_CASE(raw_encode_decode_succeeds) {
 }
 
 BOOST_AUTO_TEST_CASE(raw_encode_decode_fails) {
-    // First create an instance of an engine.
-    std::random_device rnd_device;
-    // Specify the engine and distribution.
-    std::mt19937 mersenne_engine{rnd_device()}; // Generates random integers
-    std::uniform_int_distribution<uint8_t> dist{0, 255};
-
-    auto gen = [&dist, &mersenne_engine]() { return dist(mersenne_engine); };
-
+    std::random_device rd;
+    auto lcg = MMIXLinearCongruentialGenerator(rd());
+    auto gen = [&lcg]() { return uint8_t(lcg.next()); };
     FastRandomContext randContext;
 
-    // Assert that check fails.
-    for (size_t i = 0; i < 10000; i++) {
+    // Assert that we get some XAddress::BASE58_DECODE_FAILED or
+    // XAddress::INTEGRITY_CHECK_FAILED failures.
+    for (size_t i = 0; i < 1000; i++) {
         std::vector<uint8_t> payload(20);
         std::generate(begin(payload), end(payload), gen);
         std::string encodedAddress = XAddress::Encode(
@@ -70,12 +64,39 @@ BOOST_AUTO_TEST_CASE(raw_encode_decode_fails) {
             randContext.randrange(encodedAddress.size());
         const unsigned char replacedCharacter =
             pszBase58[randContext.randrange(pszBase58.size())];
-        const bool isValid =
-            encodedAddress[mutatedPosition] == replacedCharacter;
+        const auto error = encodedAddress[mutatedPosition] == replacedCharacter
+                               ? XAddress::DECODE_OK
+                               : XAddress::BASE58_DECODE_FAILED |
+                                     XAddress::INTEGRITY_CHECK_FAILED;
         encodedAddress[mutatedPosition] = replacedCharacter;
         XAddress::Content parsedAddress;
-        BOOST_CHECK_EQUAL(XAddress::Decode(encodedAddress, parsedAddress),
-                          isValid);
+        const auto decodeResult =
+            XAddress::Decode(encodedAddress, parsedAddress);
+        // Error of one of the 2 types or passes
+        BOOST_CHECK_MESSAGE((decodeResult & ~error) == 0,
+                            "Decode or check failed: " << int(decodeResult));
+    }
+
+    // Assert that we receive a NO_NETWORK_POSITION error.
+    {
+        XAddress::Content parsedAddress;
+        const auto decodeResult =
+            XAddress::Decode("lotusabcfdsafdsafdsfdasfdsa", parsedAddress);
+        // Error of one of the 2 types or passes
+        BOOST_CHECK_MESSAGE(decodeResult == XAddress::NO_NETWORK_POSITION,
+                            "Should have errored as NO_NETWORK_POSITION: "
+                                << int(decodeResult));
+    }
+
+    // Assert that undersized payloads fail.
+    {
+        XAddress::Content parsedAddress;
+        const auto decodeResult =
+            XAddress::Decode("lotus_fdasf", parsedAddress);
+        // Error of one of the 2 types or passes
+        BOOST_CHECK_MESSAGE(decodeResult == XAddress::UNDERSIZED_PAYLOAD,
+                            "Should have errored as NO_NETWORK_POSITION: "
+                                << int(decodeResult));
     }
 }
 

--- a/src/test/xaddress_tests.cpp
+++ b/src/test/xaddress_tests.cpp
@@ -11,7 +11,6 @@
 #include <algorithm>
 #include <boost/test/unit_test.hpp>
 #include <functional>
-#include <iostream>
 #include <random>
 #include <string>
 
@@ -32,16 +31,18 @@ BOOST_AUTO_TEST_CASE(raw_encode_decode_succeeds) {
 
     // Assert that encode/decode works.
     for (size_t i = 0; i < 10000; i++) {
-        std::vector<uint8_t> payload(10);
+        std::vector<uint8_t> payload(1);
         std::generate(begin(payload), end(payload), gen);
-        const std::string encodedAddress =
-            XAddress::Encode("lotus", '_', payload);
+        const std::string encodedAddress = XAddress::Encode(
+            XAddress::Content(XAddress::TOKEN_NAME, XAddress::MAINNET,
+                              XAddress::SCRIPT_PUB_KEY, payload));
         XAddress::Content parsedAddress;
         BOOST_CHECK_EQUAL(XAddress::Decode(encodedAddress, parsedAddress),
                           true);
-        BOOST_CHECK_EQUAL(parsedAddress.token, "lotus");
-        BOOST_CHECK_MESSAGE(parsedAddress.network == uint8_t('_'),
+        BOOST_CHECK_EQUAL(parsedAddress.token, XAddress::TOKEN_NAME);
+        BOOST_CHECK_MESSAGE(parsedAddress.network == XAddress::MAINNET,
                             "Network byte incorrect");
+        BOOST_CHECK_EQUAL(parsedAddress.type, XAddress::SCRIPT_PUB_KEY);
         BOOST_CHECK_MESSAGE(parsedAddress.payload == payload,
                             "Parsed payload incorrect");
     }
@@ -60,9 +61,11 @@ BOOST_AUTO_TEST_CASE(raw_encode_decode_fails) {
 
     // Assert that check fails.
     for (size_t i = 0; i < 10000; i++) {
-        std::vector<uint8_t> payload(10);
+        std::vector<uint8_t> payload(20);
         std::generate(begin(payload), end(payload), gen);
-        std::string encodedAddress = XAddress::Encode("lotus", 'T', payload);
+        std::string encodedAddress = XAddress::Encode(
+            XAddress::Content(XAddress::TOKEN_NAME, XAddress::MAINNET,
+                              XAddress::SCRIPT_PUB_KEY, payload));
         const size_t mutatedPosition =
             randContext.randrange(encodedAddress.size());
         const unsigned char replacedCharacter =


### PR DESCRIPTION
This is the first commit required to implement parsing XAddress
formats. The basic idea is that addresses are composed of 4 parts:

1. token prefix (all lowercase word characters)
2. network byte (capital word character)
3. base58 encoded payload
4. base58 encoded 4-byte weak sha256d hash of (1)|| (2) || (3)

A follow up commit will implement processing into a `CTxDestination`
to support use in the rest of the node.