### PR TITLE
Implement encoding CTxDestinations to XAddresses

### DIFF
--- a/src/addresses/xaddress.h
+++ b/src/addresses/xaddress.h
@@ -63,6 +63,11 @@ DecodeError Decode(const std::string &address, Content &parsedOutput);
  */
 bool Parse(const CChainParams &params, const std::string &address,
            CTxDestination &retDestination);
+/**
+ * Encodes a CTxDestination to an XAddress. Returns the empty string on failure.
+ */
+std::string EncodeDestination(const CChainParams &params,
+                              const CTxDestination &dst);
 } // namespace XAddress
 
 #endif // BITCOIN_XADDR_H


### PR DESCRIPTION
Wraps XAddress::Encode in a helper function to directly create a
XAddress for Lotus from a CTxDestination. This type is used in
the wallet and rpc several places, and so support for this is
needed to connect XAddresses into the rest of the codebase.