### PR TITLE
Implement Lotus XAddresses throughout code base

### DIFF
--- a/src/addresses/xaddress.h
+++ b/src/addresses/xaddress.h
@@ -14,6 +14,8 @@
 namespace XAddress {
 
 const std::string TOKEN_NAME = "lotus";
+// Static C string for QString compatibility
+const char ADDRESS_SCHEME[] = "payto";
 
 enum NetworkType : uint8_t {
     MAINNET = '_',

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2798,9 +2798,9 @@ bool AppInitMain(Config &config, RPCServer &rpcServer,
         return false;
     }
 
-    // Encoded addresses using cashaddr instead of base58.
-    // We do this by default to avoid confusion with BTC addresses.
-    config.SetCashAddrEncoding(args.GetBoolArg("-usecashaddr", true));
+    // By default, we use XAddress; this option will make it use the CashAddr
+    // format.
+    config.SetCashAddrEncoding(args.GetBoolArg("-usecashaddr", false));
 
     // Step 8: load indexers
     if (args.GetBoolArg("-txindex", DEFAULT_TXINDEX)) {

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -4,6 +4,7 @@
 
 #include <key_io.h>
 
+#include <addresses/xaddress.h>
 #include <base58.h>
 #include <cashaddrenc.h>
 #include <chainparams.h>
@@ -170,13 +171,23 @@ std::string EncodeExtKey(const CExtKey &key) {
 std::string EncodeDestination(const CTxDestination &dest,
                               const Config &config) {
     const CChainParams &params = config.GetChainParams();
-    return config.UseCashAddrEncoding() ? EncodeCashAddr(dest, params)
-                                        : EncodeLegacyAddr(dest, params);
+    return config.UseCashAddrEncoding()
+               ? EncodeCashAddr(dest, params)
+               : XAddress::EncodeDestination(params, dest);
+}
+
+std::string EncodeDestination(const CTxDestination &dest,
+                              const CChainParams &params) {
+    return XAddress::EncodeDestination(params, dest);
 }
 
 CTxDestination DecodeDestination(const std::string &addr,
                                  const CChainParams &params) {
     CTxDestination dst = DecodeCashAddr(addr, params);
+    if (XAddress::Parse(params, addr, dst)) {
+        return dst;
+    }
+    dst = DecodeCashAddr(addr, params);
     if (IsValidDestination(dst)) {
         return dst;
     }

--- a/src/key_io.h
+++ b/src/key_io.h
@@ -26,6 +26,11 @@ CExtPubKey DecodeExtPubKey(const std::string &str);
 std::string EncodeExtPubKey(const CExtPubKey &extpubkey);
 
 std::string EncodeDestination(const CTxDestination &dest, const Config &config);
+// In some places the node configuration is not available. (e.g. QT GUI) This
+// provides a usable override that will always return the default address
+// format.
+std::string EncodeDestination(const CTxDestination &dest,
+                              const CChainParams &params);
 CTxDestination DecodeDestination(const std::string &addr, const CChainParams &);
 bool IsValidDestinationString(const std::string &str,
                               const CChainParams &params);

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -4,7 +4,6 @@
 
 #include <qt/addresstablemodel.h>
 
-#include <cashaddrenc.h>
 #include <key_io.h>
 #include <qt/guiutil.h>
 #include <qt/walletmodel.h>
@@ -82,7 +81,7 @@ public:
                 QString::fromStdString(address.purpose), address.is_mine);
             cachedAddressTable.append(AddressTableEntry(
                 addressType, QString::fromStdString(address.name),
-                QString::fromStdString(EncodeCashAddr(
+                QString::fromStdString(EncodeDestination(
                     address.dest, parent->walletModel->getChainParams()))));
         }
         // std::lower_bound() and std::upper_bound() require our
@@ -361,7 +360,7 @@ QString AddressTableModel::addRow(const QString &type, const QString &label,
                 return QString();
             }
         }
-        strAddress = EncodeCashAddr(dest, walletModel->getChainParams());
+        strAddress = EncodeDestination(dest, walletModel->getChainParams());
     } else {
         return QString();
     }

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -9,7 +9,6 @@
 #include <qt/coincontroldialog.h>
 #include <qt/forms/ui_coincontroldialog.h>
 
-#include <cashaddrenc.h>
 #include <interfaces/node.h>
 #include <key_io.h>
 #include <policy/policy.h>
@@ -675,7 +674,7 @@ void CoinControlDialog::updateView() {
     for (const auto &coins : model->wallet().listCoins()) {
         CCoinControlWidgetItem *itemWalletAddress{nullptr};
         QString sWalletAddress = QString::fromStdString(
-            EncodeCashAddr(coins.first, model->getChainParams()));
+            EncodeDestination(coins.first, model->getChainParams()));
         QString sWalletLabel =
             model->getAddressTableModel()->labelForAddress(sWalletAddress);
         if (sWalletLabel.isEmpty()) {
@@ -718,7 +717,7 @@ void CoinControlDialog::updateView() {
             QString sAddress = "";
             if (ExtractDestination(out.txout.scriptPubKey, outputAddress)) {
                 sAddress = QString::fromStdString(
-                    EncodeCashAddr(outputAddress, model->getChainParams()));
+                    EncodeDestination(outputAddress, model->getChainParams()));
 
                 // if listMode or change => show bitcoin address. In tree mode,
                 // address is not shown again for direct wallet address outputs

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -53,7 +53,7 @@ QFont fixedPitchFont();
 std::string DummyAddress(const CChainParams &params);
 
 // Convert any address into cashaddr
-QString convertToCashAddr(const CChainParams &params, const QString &addr);
+QString convertToXAddress(const CChainParams &params, const QString &addr);
 
 // Set up widget for address
 void setupAddressWidget(QValidatedLineEdit *widget, QWidget *parent);

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -4,7 +4,6 @@
 
 #include <qt/paymentserver.h>
 
-#include <cashaddrenc.h>
 #include <chainparams.h>
 #include <config.h>
 #include <interfaces/node.h>
@@ -637,7 +636,7 @@ bool PaymentServer::processPaymentRequest(const PaymentRequestPlus &request,
         if (ExtractDestination(sendingTo.first, dest)) {
             // Append destination address
             addresses.append(
-                QString::fromStdString(EncodeCashAddr(dest, Params())));
+                QString::fromStdString(EncodeDestination(dest, Params())));
         } else if (!recipient.authenticatedMerchant.isEmpty()) {
             // Unauthenticated payment requests to custom bitcoin addresses are
             // not supported (there is no good way to tell the user where they

--- a/src/qt/test/addressbooktests.cpp
+++ b/src/qt/test/addressbooktests.cpp
@@ -11,7 +11,6 @@
 #include <qt/test/util.h>
 #include <qt/walletmodel.h>
 
-#include <cashaddrenc.h>
 #include <key.h>
 #include <key_io.h>
 #include <wallet/wallet.h>
@@ -75,7 +74,7 @@ void TestAddAddressesToSendBook(interfaces::Node &node) {
             key.GetPubKey(), wallet->m_default_address_type));
 
         return std::make_pair(
-            dest, QString::fromStdString(EncodeCashAddr(dest, Params())));
+            dest, QString::fromStdString(EncodeDestination(dest, Params())));
     };
 
     CTxDestination r_key_dest, s_key_dest;

--- a/src/qt/test/guiutiltests.cpp
+++ b/src/qt/test/guiutiltests.cpp
@@ -40,14 +40,13 @@ void GUIUtilTests::toCurrentEncodingTest() {
     const CChainParams &params = config.GetChainParams();
 
     // garbage in, garbage out
-    QVERIFY(GUIUtil::convertToCashAddr(params, "garbage") == "garbage");
+    QVERIFY(GUIUtil::convertToXAddress(params, "garbage") == "garbage");
 
+    QString lotus_pubkey = "lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ";
     QString cashaddr_pubkey =
         "bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a";
-    QString base58_pubkey = "1BpEi6DfDAUFd7GtittLSdBeYJvcoaVggu";
 
-    QVERIFY(GUIUtil::convertToCashAddr(params, cashaddr_pubkey) ==
-            cashaddr_pubkey);
-    QVERIFY(GUIUtil::convertToCashAddr(params, base58_pubkey) ==
-            cashaddr_pubkey);
+    QVERIFY(GUIUtil::convertToXAddress(params, cashaddr_pubkey) ==
+            lotus_pubkey);
+    QVERIFY(GUIUtil::convertToXAddress(params, lotus_pubkey) == lotus_pubkey);
 }

--- a/src/qt/test/uritests.cpp
+++ b/src/qt/test/uritests.cpp
@@ -12,6 +12,92 @@
 
 #include <QUrl>
 
+void URITests::uriTestsLotus() {
+    const auto params = CreateChainParams(CBaseChainParams::MAIN);
+
+    SendCoinsRecipient rv;
+    QString scheme = QString("payto");
+    QUrl uri;
+    uri.setUrl(QString(
+        "lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ?req-dontexist="));
+    QVERIFY(!GUIUtil::parseBitcoinURI(scheme, uri, &rv));
+
+    uri.setUrl(QString(
+        "payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ?dontexist="));
+    QVERIFY(GUIUtil::parseBitcoinURI(scheme, uri, &rv));
+    QVERIFY(rv.address ==
+            QString("lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ"));
+    QVERIFY(rv.label == QString());
+    QVERIFY(rv.amount == Amount::zero());
+
+    uri.setUrl(
+        QString("payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ?label="
+                "Wikipedia Example Address"));
+    QVERIFY(GUIUtil::parseBitcoinURI(scheme, uri, &rv));
+    QVERIFY(rv.address ==
+            QString("lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ"));
+    QVERIFY(rv.label == QString("Wikipedia Example Address"));
+    QVERIFY(rv.amount == Amount::zero());
+
+    uri.setUrl(QString(
+        "payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ?amount=100000"));
+    QVERIFY(GUIUtil::parseBitcoinURI(scheme, uri, &rv));
+    QVERIFY(rv.address ==
+            QString("lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ"));
+    QVERIFY(rv.label == QString());
+    QVERIFY(rv.amount == 100000 * SATOSHI);
+
+    uri.setUrl(QString("payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ?"
+                       "amount=1001000"));
+    QVERIFY(GUIUtil::parseBitcoinURI(scheme, uri, &rv));
+    QVERIFY(rv.address ==
+            QString("lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ"));
+    QVERIFY(rv.label == QString());
+    QVERIFY(rv.amount == 1001000 * SATOSHI);
+
+    uri.setUrl(QString("payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ?"
+                       "amount=100000000&"
+                       "label=Wikipedia Example"));
+    QVERIFY(GUIUtil::parseBitcoinURI(scheme, uri, &rv));
+    QVERIFY(rv.address ==
+            QString("lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ"));
+    QVERIFY(rv.amount == int64_t(100000000) * SATOSHI);
+    QVERIFY(rv.label == QString("Wikipedia Example"));
+
+    uri.setUrl(
+        QString("payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ?message="
+                "Wikipedia Example Address"));
+    QVERIFY(GUIUtil::parseBitcoinURI(scheme, uri, &rv));
+    QVERIFY(rv.address ==
+            QString("lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ"));
+    QVERIFY(rv.label == QString());
+
+    QVERIFY(GUIUtil::parseBitcoinURI(
+        scheme,
+        "payto://"
+        "lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ?"
+        "message=Wikipedia Example Address",
+        &rv));
+    QVERIFY(rv.address ==
+            QString("lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ"));
+    QVERIFY(rv.label == QString());
+
+    uri.setUrl(QString(
+        "payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ?req-message="
+        "Wikipedia Example Address"));
+    QVERIFY(GUIUtil::parseBitcoinURI(scheme, uri, &rv));
+
+    uri.setUrl(QString(
+        "payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ?amount=1000000,"
+        "000&label=Wikipedia Example"));
+    QVERIFY(!GUIUtil::parseBitcoinURI(scheme, uri, &rv));
+
+    uri.setUrl(QString(
+        "payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ?amount=1000000,"
+        "000.0&label=Wikipedia Example"));
+    QVERIFY(!GUIUtil::parseBitcoinURI(scheme, uri, &rv));
+}
+
 void URITests::uriTestsCashAddr() {
     const auto params = CreateChainParams(CBaseChainParams::MAIN);
 
@@ -39,25 +125,25 @@ void URITests::uriTestsCashAddr() {
     QVERIFY(rv.label == QString("Wikipedia Example Address"));
     QVERIFY(rv.amount == Amount::zero());
 
-    uri.setUrl(QString(
-        "bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a?amount=100000"));
+    uri.setUrl(QString("bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a?"
+                       "amount=100000"));
     QVERIFY(GUIUtil::parseBitcoinURI(scheme, uri, &rv));
     QVERIFY(rv.address ==
             QString("bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a"));
     QVERIFY(rv.label == QString());
     QVERIFY(rv.amount == 100000 * SATOSHI);
 
-    uri.setUrl(QString(
-        "bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a?amount=1001000"));
+    uri.setUrl(QString("bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a?"
+                       "amount=1001000"));
     QVERIFY(GUIUtil::parseBitcoinURI(scheme, uri, &rv));
     QVERIFY(rv.address ==
             QString("bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a"));
     QVERIFY(rv.label == QString());
     QVERIFY(rv.amount == 1001000 * SATOSHI);
 
-    uri.setUrl(QString(
-        "bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a?amount=10000000000&"
-        "label=Wikipedia Example"));
+    uri.setUrl(QString("bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a?"
+                       "amount=10000000000&"
+                       "label=Wikipedia Example"));
     QVERIFY(GUIUtil::parseBitcoinURI(scheme, uri, &rv));
     QVERIFY(rv.address ==
             QString("bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a"));
@@ -106,7 +192,18 @@ void URITests::uriTestFormatURI() {
         r.address = "bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a";
         r.message = "test";
         QString uri = GUIUtil::formatBitcoinURI(*params, r);
-        QVERIFY(uri == "bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a?"
+
+        QVERIFY(uri == "lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ?"
+                       "message=test");
+    }
+
+    {
+        SendCoinsRecipient r;
+        r.address = "lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ";
+        r.message = "test";
+        QString uri = GUIUtil::formatBitcoinURI(*params, r);
+
+        QVERIFY(uri == "lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ?"
                        "message=test");
     }
 
@@ -125,7 +222,7 @@ void URITests::uriTestFormatURI() {
         r.address = "12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX";
         r.message = "test";
         QString uri = GUIUtil::formatBitcoinURI(*params, r);
-        QVERIFY(uri == "bitcoincash:qqgekzvw96vq5g57zwdfa5q6g609rrn0ycp33uc325?"
+        QVERIFY(uri == "lotus_16PSJHejVUZd1LPr51EAB4zK1Xi3D5qjQNtNHkof5?"
                        "message=test");
     }
 }

--- a/src/qt/test/uritests.h
+++ b/src/qt/test/uritests.h
@@ -12,6 +12,7 @@ class URITests : public QObject {
     Q_OBJECT
 
 private Q_SLOTS:
+    void uriTestsLotus();
     void uriTestsCashAddr();
     void uriTestFormatURI();
 };

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -1,7 +1,6 @@
 #include <qt/test/util.h>
 #include <qt/test/wallettests.h>
 
-#include <cashaddrenc.h>
 #include <chain.h>
 #include <chainparams.h>
 #include <interfaces/chain.h>
@@ -64,7 +63,7 @@ TxId SendCoins(CWallet &wallet, SendCoinsDialog &sendCoinsDialog,
     SendCoinsEntry *entry =
         qobject_cast<SendCoinsEntry *>(entries->itemAt(0)->widget());
     entry->findChild<QValidatedLineEdit *>("payTo")->setText(
-        QString::fromStdString(EncodeCashAddr(address, Params())));
+        QString::fromStdString(EncodeDestination(address, Params())));
     entry->findChild<BitcoinAmountField *>("payAmount")->setValue(amount);
     TxId txid;
     boost::signals2::scoped_connection c =
@@ -224,7 +223,7 @@ void TestGUI(interfaces::Node &node) {
             QString paymentText = rlist->toPlainText();
             QStringList paymentTextList = paymentText.split('\n');
             QCOMPARE(paymentTextList.at(0), QString("Payment information"));
-            QVERIFY(paymentTextList.at(1).indexOf(QString("URI: bchreg:")) !=
+            QVERIFY(paymentTextList.at(1).indexOf(QString("URI: lotusR")) !=
                     -1);
             QVERIFY(paymentTextList.at(2).indexOf(QString("Address:")) != -1);
             QCOMPARE(paymentTextList.at(3),

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -8,7 +8,6 @@
 
 #include <qt/transactiondesc.h>
 
-#include <cashaddrenc.h>
 #include <chain.h>
 #include <consensus/consensus.h>
 #include <interfaces/node.h>
@@ -246,8 +245,8 @@ QString TransactionDesc::toHTML(interfaces::Node &node,
                             !name.empty()) {
                             strHTML += GUIUtil::HtmlEscape(name) + " ";
                         }
-                        strHTML += GUIUtil::HtmlEscape(
-                            EncodeCashAddr(address, wallet.getChainParams()));
+                        strHTML += GUIUtil::HtmlEscape(EncodeDestination(
+                            address, wallet.getChainParams()));
                         if (toSelf == ISMINE_SPENDABLE) {
                             strHTML += " (own address)";
                         } else if (toSelf & ISMINE_WATCH_ONLY) {
@@ -425,7 +424,7 @@ QString TransactionDesc::toHTML(interfaces::Node &node,
                         strHTML += GUIUtil::HtmlEscape(name) + " ";
                     }
                     strHTML += QString::fromStdString(
-                        EncodeCashAddr(address, wallet.getChainParams()));
+                        EncodeDestination(address, wallet.getChainParams()));
                 }
                 strHTML = strHTML + " " + tr("Amount") + "=" +
                           BitcoinUnits::formatHtmlWithUnit(unit, vout.nValue);

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -4,7 +4,6 @@
 
 #include <qt/transactionrecord.h>
 
-#include <cashaddrenc.h>
 #include <chain.h>       // For MAX_BLOCK_TIME_GAP
 #include <chainparams.h> // For Params()
 #include <interfaces/wallet.h>
@@ -54,7 +53,7 @@ TransactionRecord::decomposeTransaction(const interfaces::WalletTx &wtx) {
                     // Received by Bitcoin Address
                     sub.type = TransactionRecord::RecvWithAddress;
                     sub.address =
-                        EncodeCashAddr(wtx.txout_address[i], Params());
+                        EncodeDestination(wtx.txout_address[i], Params());
                 } else {
                     // Received by IP connection (deprecated features), or a
                     // multisignature or other non-simple transaction
@@ -99,7 +98,7 @@ TransactionRecord::decomposeTransaction(const interfaces::WalletTx &wtx) {
                 if (it != wtx.txout_address.begin()) {
                     address += ", ";
                 }
-                address += EncodeCashAddr(*it, Params());
+                address += EncodeDestination(*it, Params());
             }
             Amount nChange = wtx.change;
             parts.append(TransactionRecord(
@@ -130,7 +129,7 @@ TransactionRecord::decomposeTransaction(const interfaces::WalletTx &wtx) {
                     // Sent to Bitcoin Address
                     sub.type = TransactionRecord::SendToAddress;
                     sub.address =
-                        EncodeCashAddr(wtx.txout_address[nOut], Params());
+                        EncodeDestination(wtx.txout_address[nOut], Params());
                 } else {
                     // Sent to IP, or other non-address transaction like OP_EVAL
                     sub.type = TransactionRecord::SendToOther;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -4,7 +4,6 @@
 
 #include <qt/walletmodel.h>
 
-#include <cashaddrenc.h>
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <key_io.h>
@@ -383,7 +382,7 @@ static void NotifyAddressBookChanged(WalletModel *walletmodel,
                                      const std::string &purpose,
                                      ChangeType status) {
     QString strAddress = QString::fromStdString(
-        EncodeCashAddr(address, walletmodel->getChainParams()));
+        EncodeDestination(address, walletmodel->getChainParams()));
     QString strLabel = QString::fromStdString(label);
     QString strPurpose = QString::fromStdString(purpose);
 

--- a/src/test/dstencode_tests.cpp
+++ b/src/test/dstencode_tests.cpp
@@ -40,8 +40,8 @@ BOOST_AUTO_TEST_CASE(test_addresses) {
         "bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a";
     std::string cashaddr_script =
         "bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq";
-    std::string base58_pubkey = "1BpEi6DfDAUFd7GtittLSdBeYJvcoaVggu";
-    std::string base58_script = "3CWFddi6m4ndiGyKqzYvsFYagqDLPVMTzC";
+    std::string lotus_pubkey = "lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ";
+    std::string lotus_script = "lotus_1PrQz5R11Ae1YcbvUpGDSvzPP2GsVw6EDCvZqy";
 
     DummyCashAddrConfig config;
 
@@ -50,21 +50,21 @@ BOOST_AUTO_TEST_CASE(test_addresses) {
     BOOST_CHECK_EQUAL(cashaddr_pubkey, EncodeDestination(dstKey, config));
     BOOST_CHECK_EQUAL(cashaddr_script, EncodeDestination(dstScript, config));
     config.SetCashAddrEncoding(false);
-    BOOST_CHECK_EQUAL(base58_pubkey, EncodeDestination(dstKey, config));
-    BOOST_CHECK_EQUAL(base58_script, EncodeDestination(dstScript, config));
+    BOOST_CHECK_EQUAL(lotus_pubkey, EncodeDestination(dstKey, config));
+    BOOST_CHECK_EQUAL(lotus_script, EncodeDestination(dstScript, config));
 
     // Check decoding
     const CChainParams &params = config.GetChainParams();
     BOOST_CHECK(dstKey == DecodeDestination(cashaddr_pubkey, params));
     BOOST_CHECK(dstScript == DecodeDestination(cashaddr_script, params));
-    BOOST_CHECK(dstKey == DecodeDestination(base58_pubkey, params));
-    BOOST_CHECK(dstScript == DecodeDestination(base58_script, params));
+    BOOST_CHECK(dstKey == DecodeDestination(lotus_pubkey, params));
+    BOOST_CHECK(dstScript == DecodeDestination(lotus_script, params));
 
     // Validation
     BOOST_CHECK(IsValidDestinationString(cashaddr_pubkey, params));
     BOOST_CHECK(IsValidDestinationString(cashaddr_script, params));
-    BOOST_CHECK(IsValidDestinationString(base58_pubkey, params));
-    BOOST_CHECK(IsValidDestinationString(base58_script, params));
+    BOOST_CHECK(IsValidDestinationString(lotus_pubkey, params));
+    BOOST_CHECK(IsValidDestinationString(lotus_script, params));
     BOOST_CHECK(!IsValidDestinationString("notvalid", params));
 }
 

--- a/test/util/data/bitcoin-util-test.json
+++ b/test/util/data/bitcoin-util-test.json
@@ -227,7 +227,7 @@
     "exec": "./lotus-tx",
     "args": [
       "-create",
-      "outaddr=100.:13tuJJDR2RgArmgfv6JScSdreahzgc4T6o:garbage"
+      "outaddr=100.:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF:garbage"
     ],
     "return_code": 1,
     "error_txt": "error: TX output missing or too many separators",
@@ -260,8 +260,8 @@
       "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
       "in=bf829c6bcf84579331337659d31f89dfd138f7f7785802d5501c92333145ca7c:18",
       "in=22a6f904655d53ae2ff70e701a0bbd90aa3975c0f40bfc6cc996a9049e31cdfc:1",
-      "outaddr=18:13tuJJDR2RgArmgfv6JScSdreahzgc4T6o",
-      "outaddr=400.:1P8yWvZW8jVihP1bzHeqfE4aoXNX8AVa46"
+      "outaddr=18:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF",
+      "outaddr=400.:lotus_16PSJQYjnqavSN7kQKQCQ29cRFrot99aLLg4iHj7R"
     ],
     "output_cmp": "txcreate1.hex",
     "description": "Creates a new transaction with three inputs and two outputs"
@@ -274,8 +274,8 @@
       "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
       "in=bf829c6bcf84579331337659d31f89dfd138f7f7785802d5501c92333145ca7c:18",
       "in=22a6f904655d53ae2ff70e701a0bbd90aa3975c0f40bfc6cc996a9049e31cdfc:1",
-      "outaddr=18:13tuJJDR2RgArmgfv6JScSdreahzgc4T6o",
-      "outaddr=400.:1P8yWvZW8jVihP1bzHeqfE4aoXNX8AVa46"
+      "outaddr=18:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF",
+      "outaddr=400.:lotus_16PSJQYjnqavSN7kQKQCQ29cRFrot99aLLg4iHj7R"
     ],
     "output_cmp": "txcreate1.json",
     "description": "Creates a new transaction with three inputs and two outputs (output in json)"
@@ -434,7 +434,7 @@
       "in=4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485:0",
       "set=privatekeys:[\"5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf\"]",
       "set=prevtxs:[{\"txid\":\"4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485\",\"vout\":0,\"scriptPubKey\":\"76a91491b24bf9f5288532960ac687abb035127b1d28a588ac\"}]",
-      "outaddr=0.1:193P6LtvS4nCnkDvM9uXn1gsSRqh4aDAz7",
+      "outaddr=0.1:lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ze3Ark",
       "sign=ALL|FORKID"
     ],
     "output_cmp": "txcreatesignv1.hex",
@@ -449,7 +449,7 @@
       "in=4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485:0",
       "set=privatekeys:[\"5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf\"]",
       "set=prevtxs:[{\"txid\":\"4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485\",\"vout\":0,\"scriptPubKey\":\"76a91491b24bf9f5288532960ac687abb035127b1d28a588ac\"}]",
-      "outaddr=0.1:193P6LtvS4nCnkDvM9uXn1gsSRqh4aDAz7",
+      "outaddr=0.1:lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ze3Ark",
       "sign=ALL|FORKID"
     ],
     "output_cmp": "txcreatesignv1.json",
@@ -462,7 +462,7 @@
       "in=4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485:0",
       "set=privatekeys:[\"5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf\"]",
       "set=prevtxs:[{\"txid\":\"4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485\",\"vout\":0,\"scriptPubKey\":\"76a91491b24bf9f5288532960ac687abb035127b1d28a588ac\"}]",
-      "outaddr=0.1:193P6LtvS4nCnkDvM9uXn1gsSRqh4aDAz7",
+      "outaddr=0.1:lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ze3Ark",
       "sign=ALL|FORKID"
     ],
     "output_cmp": "txcreatesignv2.hex",
@@ -475,7 +475,7 @@
       "in=4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485:0",
       "set=privatekeys:[\"5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf\"]",
       "set=prevtxs:[{\"txid\":\"4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485\",\"vout\":0,\"scriptPubKey\":\"76a91491b24bf9f5288532960ac687abb035127b1d28a588ac\"}]",
-      "outaddr=0.1:193P6LtvS4nCnkDvM9uXn1gsSRqh4aDAz7",
+      "outaddr=0.1:lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ze3Ark",
       "sign=SINGLE|FORKID"
     ],
     "output_cmp": "txcreatesignv2-single.hex",
@@ -488,7 +488,7 @@
       "in=4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485:0",
       "set=privatekeys:[\"5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf\"]",
       "set=prevtxs:[{\"txid\":\"4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485\",\"vout\":\"0foo\",\"scriptPubKey\":\"76a91491b24bf9f5288532960ac687abb035127b1d28a588ac\"}]",
-      "outaddr=0.1:193P6LtvS4nCnkDvM9uXn1gsSRqh4aDAz7",
+      "outaddr=0.1:lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ze3Ark",
       "sign=ALL|FORKID"
     ],
     "return_code": 1,
@@ -502,7 +502,7 @@
       "in=4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485:0",
       "set=privatekeys:[\"5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf\"]",
       "set=prevtxs:[{\"txid\":\"Zd49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59412\",\"vout\":0,\"scriptPubKey\":\"76a91491b24bf9f5288532960ac687abb035127b1d28a588ac\"}]",
-      "outaddr=0.1:193P6LtvS4nCnkDvM9uXn1gsSRqh4aDAz7",
+      "outaddr=0.1:lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ze3Ark",
       "sign=ALL|FORKID"
     ],
     "return_code": 1,
@@ -516,7 +516,7 @@
       "in=4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485:0",
       "set=privatekeys:[\"5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf\"]",
       "set=prevtxs:[{\"txid\":\"4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc594\",\"vout\":0,\"scriptPubKey\":\"76a91491b24bf9f5288532960ac687abb035127b1d28a588ac\"}]",
-      "outaddr=0.1:193P6LtvS4nCnkDvM9uXn1gsSRqh4aDAz7",
+      "outaddr=0.1:lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ze3Ark",
       "sign=ALL|FORKID"
     ],
     "return_code": 1,
@@ -530,7 +530,7 @@
       "in=4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485:0",
       "set=privatekeys:[\"5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf\"]",
       "set=prevtxs:[{\"txid\":\"4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc5948512\",\"vout\":0,\"scriptPubKey\":\"76a91491b24bf9f5288532960ac687abb035127b1d28a588ac\"}]",
-      "outaddr=0.1:193P6LtvS4nCnkDvM9uXn1gsSRqh4aDAz7",
+      "outaddr=0.1:lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ze3Ark",
       "sign=ALL|FORKID"
     ],
     "return_code": 1,
@@ -684,7 +684,7 @@
     "args": [
       "-create",
       "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
-      "outaddr=18:13tuJJDR2RgArmgfv6JScSdreahzgc4T6o",
+      "outaddr=18:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF",
       "outdata=400:54686973204f505f52455455524e207472616e73616374696f6e206f7574707574207761732063726561746564206279206d6f646966696564206372656174657261777472616e73616374696f6e2e"
     ],
     "output_cmp": "txcreatedata1.hex",
@@ -697,7 +697,7 @@
       "-create",
       "nversion=1",
       "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
-      "outaddr=18:13tuJJDR2RgArmgfv6JScSdreahzgc4T6o",
+      "outaddr=18:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF",
       "outdata=400:54686973204f505f52455455524e207472616e73616374696f6e206f7574707574207761732063726561746564206279206d6f646966696564206372656174657261777472616e73616374696f6e2e"
     ],
     "output_cmp": "txcreatedata1.json",
@@ -708,7 +708,7 @@
     "args": [
       "-create",
       "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
-      "outaddr=18:13tuJJDR2RgArmgfv6JScSdreahzgc4T6o",
+      "outaddr=18:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF",
       "outdata=54686973204f505f52455455524e207472616e73616374696f6e206f7574707574207761732063726561746564206279206d6f646966696564206372656174657261777472616e73616374696f6e2e"
     ],
     "output_cmp": "txcreatedata2.hex",
@@ -720,7 +720,7 @@
       "-json",
       "-create",
       "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
-      "outaddr=18:13tuJJDR2RgArmgfv6JScSdreahzgc4T6o",
+      "outaddr=18:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF",
       "outdata=54686973204f505f52455455524e207472616e73616374696f6e206f7574707574207761732063726561746564206279206d6f646966696564206372656174657261777472616e73616374696f6e2e"
     ],
     "output_cmp": "txcreatedata2.json",
@@ -731,7 +731,7 @@
     "args": [
       "-create",
       "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0:4294967293",
-      "outaddr=18:13tuJJDR2RgArmgfv6JScSdreahzgc4T6o"
+      "outaddr=18:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF"
     ],
     "output_cmp": "txcreatedata_seq0.hex",
     "description": "Creates a new transaction with one input with sequence number and one address output"
@@ -742,7 +742,7 @@
       "-json",
       "-create",
       "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0:4294967293",
-      "outaddr=18:13tuJJDR2RgArmgfv6JScSdreahzgc4T6o"
+      "outaddr=18:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF"
     ],
     "output_cmp": "txcreatedata_seq0.json",
     "description": "Creates a new transaction with one input with sequence number and one address output (output in json)"

--- a/test/util/data/tt-delin1-out.json
+++ b/test/util/data/tt-delin1-out.json
@@ -196,7 +196,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "1E7SGgAZFCHDnVZLuRViX3gUmxpMfdvd2o"
+                    "lotus_16PSJMWtSC9SNZo93u1QKxQk8m17xF9RvZwi8Xoxj"
                 ]
             }
         },
@@ -209,7 +209,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "1AtWkdmfmYkErU16d3KYykJUbEp9MAj9Sb"
+                    "lotus_16PSJLS6tQYrdEhn2rLpBvDqdbrgUADpiAqhUxBcJ"
                 ]
             }
         }

--- a/test/util/data/tt-delout1-out.json
+++ b/test/util/data/tt-delout1-out.json
@@ -205,7 +205,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "1E7SGgAZFCHDnVZLuRViX3gUmxpMfdvd2o"
+                    "lotus_16PSJMWtSC9SNZo93u1QKxQk8m17xF9RvZwi8Xoxj"
                 ]
             }
         }

--- a/test/util/data/tt-locktime317000-out.json
+++ b/test/util/data/tt-locktime317000-out.json
@@ -205,7 +205,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "1E7SGgAZFCHDnVZLuRViX3gUmxpMfdvd2o"
+                    "lotus_16PSJMWtSC9SNZo93u1QKxQk8m17xF9RvZwi8Xoxj"
                 ]
             }
         },
@@ -218,7 +218,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "1AtWkdmfmYkErU16d3KYykJUbEp9MAj9Sb"
+                    "lotus_16PSJLS6tQYrdEhn2rLpBvDqdbrgUADpiAqhUxBcJ"
                 ]
             }
         }

--- a/test/util/data/txcreate1.json
+++ b/test/util/data/txcreate1.json
@@ -43,7 +43,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "13tuJJDR2RgArmgfv6JScSdreahzgc4T6o"
+                    "lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF"
                 ]
             }
         },
@@ -56,7 +56,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "1P8yWvZW8jVihP1bzHeqfE4aoXNX8AVa46"
+                    "lotus_16PSJQYjnqavSN7kQKQCQ29cRFrot99aLLg4iHj7R"
                 ]
             }
         }

--- a/test/util/data/txcreatedata1.json
+++ b/test/util/data/txcreatedata1.json
@@ -25,7 +25,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "13tuJJDR2RgArmgfv6JScSdreahzgc4T6o"
+                    "lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF"
                 ]
             }
         },

--- a/test/util/data/txcreatedata2.json
+++ b/test/util/data/txcreatedata2.json
@@ -25,7 +25,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "13tuJJDR2RgArmgfv6JScSdreahzgc4T6o"
+                    "lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF"
                 ]
             }
         },

--- a/test/util/data/txcreatedata_seq0.json
+++ b/test/util/data/txcreatedata_seq0.json
@@ -25,7 +25,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "13tuJJDR2RgArmgfv6JScSdreahzgc4T6o"
+                    "lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF"
                 ]
             }
         }

--- a/test/util/data/txcreatedata_seq1.json
+++ b/test/util/data/txcreatedata_seq1.json
@@ -34,7 +34,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "13tuJJDR2RgArmgfv6JScSdreahzgc4T6o"
+                    "lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF"
                 ]
             }
         }

--- a/test/util/data/txcreatemultisig1.json
+++ b/test/util/data/txcreatemultisig1.json
@@ -16,9 +16,9 @@
                 "reqSigs": 2,
                 "type": "multisig",
                 "addresses": [
-                    "1FoG2386FG2tAJS9acMuiDsKy67aGg9MKz",
-                    "1FXtz9KU8JNmQDyHdiEm5HDiALuP3zdHvV",
-                    "14LuavcBbXZYJ6Tsz3cAUQj9SuQoL2xCQX"
+                    "lotus_16PSJN5kBhektivFSZFAupfjHMxpbtWptZNbLuyFM",
+                    "lotus_16PSJMzatzDc8DpNfUyFtaY1bapfUtGCJvoLbX2FP",
+                    "lotus_16PSJJEbZRoYf1RPfQTRTrKyFyqLTVAPDJd7vcE54"
                 ]
             }
         }

--- a/test/util/data/txcreatemultisig2.json
+++ b/test/util/data/txcreatemultisig2.json
@@ -16,7 +16,7 @@
                 "reqSigs": 1,
                 "type": "scripthash",
                 "addresses": [
-                    "34HNh57oBCRKkxNyjTuWAJkTbuGh6jg2Ms"
+                    "lotus_1PrQMnaABKEQ4JYgJkfSdfoLfAhbjquZNBjJ6Z"
                 ]
             }
         }

--- a/test/util/data/txcreatescript2.json
+++ b/test/util/data/txcreatescript2.json
@@ -16,7 +16,7 @@
                 "reqSigs": 1,
                 "type": "scripthash",
                 "addresses": [
-                    "3C5QarEGh9feKbDJ3QbMf2YNjnMoiPDhNp"
+                    "lotus_1PrQxBkWiRorG9kcMKvFq3hoRdN8XLUy6HX3dA"
                 ]
             }
         }

--- a/test/util/data/txcreatesignlotusv1-all.json
+++ b/test/util/data/txcreatesignlotusv1-all.json
@@ -25,7 +25,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "1cMh228HTCiwS8ZsaakH8A8wze1JR5ZsP"
+                    "lotus_16PSJHKLkxiakqViQDC1rKbuWhdJW3xE9X3p8XuJ2"
                 ]
             }
         }

--- a/test/util/data/txcreatesignlotusv2-all-anyonecanpay.json
+++ b/test/util/data/txcreatesignlotusv2-all-anyonecanpay.json
@@ -25,7 +25,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "1cMh228HTCiwS8ZsaakH8A8wze1JR5ZsP"
+                    "lotus_16PSJHKLkxiakqViQDC1rKbuWhdJW3xE9X3p8XuJ2"
                 ]
             }
         }

--- a/test/util/data/txcreatesignlotusv2-all.json
+++ b/test/util/data/txcreatesignlotusv2-all.json
@@ -25,7 +25,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "1cMh228HTCiwS8ZsaakH8A8wze1JR5ZsP"
+                    "lotus_16PSJHKLkxiakqViQDC1rKbuWhdJW3xE9X3p8XuJ2"
                 ]
             }
         }

--- a/test/util/data/txcreatesignlotusv2-none-anyonecanpay.json
+++ b/test/util/data/txcreatesignlotusv2-none-anyonecanpay.json
@@ -25,7 +25,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "1cMh228HTCiwS8ZsaakH8A8wze1JR5ZsP"
+                    "lotus_16PSJHKLkxiakqViQDC1rKbuWhdJW3xE9X3p8XuJ2"
                 ]
             }
         }

--- a/test/util/data/txcreatesignlotusv2-none.json
+++ b/test/util/data/txcreatesignlotusv2-none.json
@@ -25,7 +25,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "1cMh228HTCiwS8ZsaakH8A8wze1JR5ZsP"
+                    "lotus_16PSJHKLkxiakqViQDC1rKbuWhdJW3xE9X3p8XuJ2"
                 ]
             }
         }

--- a/test/util/data/txcreatesignlotusv2-single-anyonecanpay.json
+++ b/test/util/data/txcreatesignlotusv2-single-anyonecanpay.json
@@ -25,7 +25,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "1cMh228HTCiwS8ZsaakH8A8wze1JR5ZsP"
+                    "lotus_16PSJHKLkxiakqViQDC1rKbuWhdJW3xE9X3p8XuJ2"
                 ]
             }
         }

--- a/test/util/data/txcreatesignlotusv2-single.json
+++ b/test/util/data/txcreatesignlotusv2-single.json
@@ -25,7 +25,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "1cMh228HTCiwS8ZsaakH8A8wze1JR5ZsP"
+                    "lotus_16PSJHKLkxiakqViQDC1rKbuWhdJW3xE9X3p8XuJ2"
                 ]
             }
         }

--- a/test/util/data/txcreatesignv1.json
+++ b/test/util/data/txcreatesignv1.json
@@ -25,7 +25,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "193P6LtvS4nCnkDvM9uXn1gsSRqh4aDAz7"
+                    "lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ze3Ark"
                 ]
             }
         }


### PR DESCRIPTION
In previous commits we implemented parsing and encoding for Lotus
XAddresses. This commit implements them throughout the QT GUI, the RPC,
and lotus-tx as the default address format. CashAddrs and Legacy
addresses are still supported, but are automatic fallbacks.