### PR TITLE
Implement random selection of output addresses based on epoch block

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -16,6 +16,10 @@
 #include <util/strencodings.h>
 #include <util/system.h>
 
+#include <consensus/addresses_mainnet.h>
+#include <consensus/addresses_regtest.h>
+#include <consensus/addresses_testnet.h>
+
 #include <cassert>
 
 /**
@@ -82,7 +86,11 @@ public:
 
         // The miner fund is enabled by default on mainnet.
         consensus.enableMinerFund = ENABLE_MINER_FUND;
-
+        consensus.payoutAddressSets = RewardAddresses::MainNet::AddressSets;
+        assert(consensus.payoutAddressSets.size() == 13);
+        for (const auto &addressSet : consensus.payoutAddressSets) {
+            assert(addressSet.size() > 0);
+        }
         // Mainnet rewards based on difficulty.
         consensus.enableDifficultyBasedSubsidy = true;
 
@@ -197,6 +205,11 @@ public:
 
         // The miner fund is enabled by default on testnet.
         consensus.enableMinerFund = ENABLE_MINER_FUND;
+        consensus.payoutAddressSets = RewardAddresses::TestNet::AddressSets;
+        assert(consensus.payoutAddressSets.size() == 13);
+        for (const auto &addressSet : consensus.payoutAddressSets) {
+            assert(addressSet.size() > 0);
+        }
 
         // Testnet rewards based on difficulty.
         consensus.enableDifficultyBasedSubsidy = true;
@@ -293,7 +306,11 @@ public:
 
         // The miner fund is disabled by default on regnet.
         consensus.enableMinerFund = false;
-
+        consensus.payoutAddressSets = RewardAddresses::RegTest::AddressSets;
+        assert(consensus.payoutAddressSets.size() == 13);
+        for (const auto &addressSet : consensus.payoutAddressSets) {
+            assert(addressSet.size() > 0);
+        }
         // Regtest rewards a constant amount independent of difficulty.
         consensus.enableDifficultyBasedSubsidy = false;
 

--- a/src/consensus/addresses_mainnet.h
+++ b/src/consensus/addresses_mainnet.h
@@ -1,0 +1,35 @@
+#include <string>
+#include <vector>
+
+namespace RewardAddresses {
+namespace MainNet {
+    std::vector<std::vector<std::string>> AddressSets = {
+        // Foundation
+        {"pzmv0yp3kuwcd2cdv9lpu8nsdmzwud9s0upp4rxwc9"},
+        // Bitcoin ABC
+        {"ppppwzhcy6kyyhkjsw0s7vvyzxz73vnwzynkaqjssk"},
+        // Be.Cash
+        {"qpwm9atcqdmr2dutnpp5h0t0hmy0y6k595qg0z5egm"},
+        // Saipan Institute
+        {"qrd8dgcmvasdewg2535uzkt9mfhgqztwg504dhsfxc"},
+        // Stamp
+        {"qqfjt5kchfhgclvelandy9fsj97vwdpf6g7sfclqsh"},
+        // Nghia
+        {"qp4pwxy34w2yxqst6f64aauudev7l3vjv5xg6dhc7x"},
+        // Remark
+        {"qqv73kxsak4ka3plqjm9d0lh9tmc6cllv5m9np8ndy"},
+        // Bitcoin Not Bombs
+        {"qrryjt2wgnwdqpg7vz52m440q2e09ydj4gupmhu3g6"},
+        // Distro Bot
+        {"qz66atlvnu5hyygvf340j5y283q7r5788vkcu6qff3"},
+        // Distro Bot
+        {"qp7z3253hyl6lzhwpfjjpg9g8apdh39ytvlwfx57mm"},
+        // Evangelism
+        {"qzccavyvf9uwwdyqwsa3txqxr5708rss4qqg8p6an4"},
+        // Distro Bot
+        {"qp7s3y735fut4vn70tvjakyt6lww4lvr55ljvaxpyn"},
+        // Koush
+        {"qrgqdz7ww5v8yqgu9ns4av5m4t4w7jxgyyxc05z9gu"},
+    };
+} // namespace MainNet
+} // namespace RewardAddresses

--- a/src/consensus/addresses_regtest.h
+++ b/src/consensus/addresses_regtest.h
@@ -1,0 +1,35 @@
+#include <string>
+#include <vector>
+
+namespace RewardAddresses {
+namespace RegTest {
+    std::vector<std::vector<std::string>> AddressSets = {
+        // Foundation
+        {"pzmv0yp3kuwcd2cdv9lpu8nsdmzwud9s0upp4rxwc9"},
+        // Bitcoin ABC
+        {"ppppwzhcy6kyyhkjsw0s7vvyzxz73vnwzynkaqjssk"},
+        // Be.Cash
+        {"qpwm9atcqdmr2dutnpp5h0t0hmy0y6k595qg0z5egm"},
+        // Saipan Institute
+        {"qrd8dgcmvasdewg2535uzkt9mfhgqztwg504dhsfxc"},
+        // Stamp
+        {"qqfjt5kchfhgclvelandy9fsj97vwdpf6g7sfclqsh"},
+        // Nghia
+        {"qp4pwxy34w2yxqst6f64aauudev7l3vjv5xg6dhc7x"},
+        // Remark
+        {"qqv73kxsak4ka3plqjm9d0lh9tmc6cllv5m9np8ndy"},
+        // Bitcoin Not Bombs
+        {"qrryjt2wgnwdqpg7vz52m440q2e09ydj4gupmhu3g6"},
+        // Distro Bot
+        {"qz66atlvnu5hyygvf340j5y283q7r5788vkcu6qff3"},
+        // Distro Bot
+        {"qp7z3253hyl6lzhwpfjjpg9g8apdh39ytvlwfx57mm"},
+        // Evangelism
+        {"qzccavyvf9uwwdyqwsa3txqxr5708rss4qqg8p6an4"},
+        // Distro Bot
+        {"qp7s3y735fut4vn70tvjakyt6lww4lvr55ljvaxpyn"},
+        // Koush
+        {"qrgqdz7ww5v8yqgu9ns4av5m4t4w7jxgyyxc05z9gu"},
+    };
+} // namespace RegTest
+} // namespace RewardAddresses

--- a/src/consensus/addresses_testnet.h
+++ b/src/consensus/addresses_testnet.h
@@ -1,0 +1,35 @@
+#include <string>
+#include <vector>
+
+namespace RewardAddresses {
+namespace TestNet {
+    std::vector<std::vector<std::string>> AddressSets = {
+        // Foundation
+        {"pzmv0yp3kuwcd2cdv9lpu8nsdmzwud9s0upp4rxwc9"},
+        // Bitcoin ABC
+        {"ppppwzhcy6kyyhkjsw0s7vvyzxz73vnwzynkaqjssk"},
+        // Be.Cash
+        {"qpwm9atcqdmr2dutnpp5h0t0hmy0y6k595qg0z5egm"},
+        // Saipan Institute
+        {"qrd8dgcmvasdewg2535uzkt9mfhgqztwg504dhsfxc"},
+        // Stamp
+        {"qqfjt5kchfhgclvelandy9fsj97vwdpf6g7sfclqsh"},
+        // Nghia
+        {"qp4pwxy34w2yxqst6f64aauudev7l3vjv5xg6dhc7x"},
+        // Remark
+        {"qqv73kxsak4ka3plqjm9d0lh9tmc6cllv5m9np8ndy"},
+        // Bitcoin Not Bombs
+        {"qrryjt2wgnwdqpg7vz52m440q2e09ydj4gupmhu3g6"},
+        // Distro Bot
+        {"qz66atlvnu5hyygvf340j5y283q7r5788vkcu6qff3"},
+        // Distro Bot
+        {"qp7z3253hyl6lzhwpfjjpg9g8apdh39ytvlwfx57mm"},
+        // Evangelism
+        {"qzccavyvf9uwwdyqwsa3txqxr5708rss4qqg8p6an4"},
+        // Distro Bot
+        {"qp7s3y735fut4vn70tvjakyt6lww4lvr55ljvaxpyn"},
+        // Koush
+        {"qrgqdz7ww5v8yqgu9ns4av5m4t4w7jxgyyxc05z9gu"},
+    };
+} // namespace TestNet
+} // namespace RewardAddresses

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -7,6 +7,7 @@
 #define BITCOIN_CONSENSUS_PARAMS_H
 
 #include <primitives/blockhash.h>
+#include <script/script.h>
 #include <uint256.h>
 
 #include <limits>
@@ -31,6 +32,7 @@ struct Params {
 
     /** Enable or disable the miner fund by default */
     bool enableMinerFund;
+    std::vector<std::vector<std::string>> payoutAddressSets;
 
     bool enableDifficultyBasedSubsidy;
 

--- a/src/minerfund.h
+++ b/src/minerfund.h
@@ -17,6 +17,10 @@ namespace Consensus {
 struct Params;
 }
 
+const CTxOut BuildRandomOutput(const std::vector<std::string> &addressList,
+                               uint64_t slot, Amount shareAmount,
+                               uint256 epochBlockHash);
+
 std::vector<CTxOut> GetMinerFundRequiredOutputs(const Consensus::Params &params,
                                                 const bool enableMinerFund,
                                                 const CBlockIndex *pindexPrev,

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -173,6 +173,7 @@ add_boost_unit_tests_to_suite(bitcoin test_lotus
 		merkle_tests.cpp
 		merkleblock_tests.cpp
 		miner_tests.cpp
+		minerfund_tests.cpp
 		monolith_opcodes_tests.cpp
 		multisig_tests.cpp
 		net_tests.cpp

--- a/src/test/minerfund_tests.cpp
+++ b/src/test/minerfund_tests.cpp
@@ -1,0 +1,272 @@
+// Copyright (c) 2021 The Logos Foundation
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <addresses/xaddress.h>
+#include <blockdb.h>
+#include <chain.h>
+#include <chainparams.h>
+#include <coins.h>
+#include <config.h>
+#include <consensus/consensus.h>
+#include <consensus/merkle.h>
+#include <consensus/tx_verify.h>
+#include <consensus/validation.h>
+#include <core_io.h>
+#include <key_io.h>
+#include <miner.h>
+#include <minerfund.h>
+#include <policy/policy.h>
+#include <pow/pow.h>
+#include <script/standard.h>
+#include <uint256.h>
+#include <util/system.h>
+#include <util/time.h>
+#include <validation.h>
+
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <functional>
+#include <random>
+#include <string>
+
+#include <minerfund.h>
+#include <util/strencodings.h>
+
+BOOST_FIXTURE_TEST_SUITE(minerfund_tests, TestChain100Setup)
+
+static void TestOutputsInSet(
+    const std::vector<CTxOut> &outputs,
+    const std::vector<CTxOut> &coinbaseOutputs,
+    std::vector<std::vector<CTxDestination>> &allowedDestinationSets) {
+    std::vector<CTxDestination> emptySet;
+    // Check random funding address outputs
+    auto outputsIt = outputs.begin();
+    auto coinbaseOutsIt = coinbaseOutputs.begin() + 2;
+    for (size_t idx = 0; idx < 12; idx++) {
+        const auto &allowedSet = allowedDestinationSets[idx];
+        BOOST_CHECK_MESSAGE(outputsIt->scriptPubKey ==
+                                coinbaseOutsIt->scriptPubKey,
+                            "Mismatched scriptPubKey on coinbase");
+        BOOST_CHECK_MESSAGE(outputsIt->nValue == coinbaseOutsIt->nValue,
+                            "Mismatched coinbase value of output");
+
+        CTxDestination dest;
+        ExtractDestination(outputsIt->scriptPubKey, dest);
+
+        const auto foundTx =
+            std::find_if(allowedSet.begin(), allowedSet.end(),
+                         [dest](const auto &a) -> bool { return dest == a; });
+        BOOST_CHECK_MESSAGE(
+            foundTx != allowedSet.end(),
+            "Infrastructure coinbase payout not found in allowable set");
+
+        // Check that we're ensuring destinations match
+        const auto isInEmptySet =
+            std::find_if(emptySet.begin(), emptySet.end(),
+                         [dest](const auto &a) -> bool { return dest == a; });
+        BOOST_CHECK_MESSAGE(isInEmptySet == emptySet.end(),
+                            "CTxDestination operator equality failing");
+        outputsIt++;
+        coinbaseOutsIt++;
+    }
+}
+
+static size_t CompareOutputs(const std::vector<CTxOut> &outputsA,
+                             const std::vector<CTxOut> &outputsB) {
+    std::vector<CTxDestination> emptySet;
+    // Check random funding address outputs only
+    auto outputsAIt = outputsA.begin() + 2;
+    auto outputsBIt = outputsB.begin() + 2;
+    BOOST_CHECK_MESSAGE(outputsA.size() == outputsB.size(),
+                        "Mismatched coinbase output count");
+    size_t matches = 0;
+    for (size_t idx = 2; idx < outputsA.size(); idx++) {
+        BOOST_CHECK_MESSAGE(outputsAIt->nValue == outputsBIt->nValue,
+                            "Mismatched coinbase value of output");
+        matches += outputsAIt->scriptPubKey != outputsBIt->scriptPubKey;
+        outputsAIt++;
+        outputsBIt++;
+    }
+    return matches < outputsA.size() - 2;
+}
+
+BOOST_AUTO_TEST_CASE(test_outputs) {
+    // Note that by default, these tests run with size accounting enabled.
+    GlobalConfig config;
+    // Don't check this functionality in this test.
+    config.SetEnableMinerFund(true);
+    const CChainParams &chainparams = config.GetChainParams();
+    // We mine some blocks, thus we need some basic setup.
+    BlockAssembler::Options options;
+    options.blockMinFeeRate = CFeeRate(1000 * SATOSHI, 1000);
+    options.enableMinerFund = config.EnableMinerFund();
+    auto testAssembler = BlockAssembler(chainparams, *m_node.mempool, options);
+
+    const auto &consensus = chainparams.GetConsensus();
+    // Simple consensus transaction.
+    CScript scriptPubKey = CScript() << OP_RETURN;
+    std::unique_ptr<CBlockTemplate> pblocktemplate;
+
+    fCheckpointsEnabled = false;
+
+    const auto mainNetParams = CreateChainParams(CBaseChainParams::MAIN);
+
+    // Normalize addresses for search purposes
+    std::vector<std::vector<CTxDestination>> payoutAddressDestinations;
+    for (const auto &addressSet : consensus.payoutAddressSets) {
+        payoutAddressDestinations.emplace_back(std::vector<CTxDestination>());
+        for (const auto &address : addressSet) {
+            payoutAddressDestinations.back().emplace_back(
+                DecodeDestination(address, *mainNetParams));
+        }
+    }
+
+    // At least two blocks should have different epochs
+    size_t differentBlocks = 0;
+    for (size_t i = 0; i < 5002; i++) {
+        // Simple block creation
+        BOOST_CHECK(pblocktemplate =
+                        testAssembler.CreateNewBlock(scriptPubKey));
+        CBlock *pblock = &pblocktemplate->block;
+        const auto &coinbaseOutputs = pblock->vtx[0]->vout;
+        const auto pPrev = ::ChainActive().Tip();
+        const auto pPrevPrev = pPrev->pprev;
+
+        // Output hashes are based on previous block's epoch.
+        if (pPrev->hashEpochBlock != pPrevPrev->hashEpochBlock) {
+            differentBlocks++;
+            CBlock block;
+            ReadBlockFromDisk(block, pPrev,
+                              config.GetChainParams().GetConsensus());
+
+            const auto commonOutputs =
+                CompareOutputs(block.vtx[0]->vout, coinbaseOutputs);
+            BOOST_CHECK_MESSAGE(
+                commonOutputs < 5,
+                "Coinbase outputs matched when they should not have: "
+                    << commonOutputs);
+        }
+        const auto subsidy =
+            GetBlockSubsidy(::ChainActive().Tip()->nBits, consensus);
+        const auto outputs = GetMinerFundRequiredOutputs(
+            consensus, true, ::ChainActive().Tip(), subsidy);
+        // outputs + 2 for OP_RETURN for block height unique hash, and
+        // coinbase output
+        BOOST_CHECK_MESSAGE(outputs.size() + 2 == coinbaseOutputs.size(),
+                            "Mismatch coinbase size");
+
+        // OP_RETURN Commitment, Miner payout, and funding set
+        BOOST_CHECK_EQUAL(coinbaseOutputs.size(), 15);
+
+        // Check random funding address outputs
+        TestOutputsInSet(outputs, coinbaseOutputs, payoutAddressDestinations);
+
+        // Update block so it can be connected, and the epoch will update
+        // through this test.
+        UpdateTime(pblock, chainparams, ::ChainActive().Tip());
+        pblock->nNonce = 0;
+        pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
+        const Consensus::Params &params =
+            config.GetChainParams().GetConsensus();
+        while (!CheckProofOfWork(pblock->GetHash(), pblock->nBits, params)) {
+            ++pblock->nNonce;
+        }
+        std::shared_ptr<const CBlock> shared_pblock =
+            std::make_shared<const CBlock>(*pblock);
+
+        BOOST_CHECK(
+            Assert(m_node.chainman)
+                ->ProcessNewBlock(config, shared_pblock, true, nullptr));
+    }
+
+    BOOST_CHECK_MESSAGE(differentBlocks > 0,
+                        "Should have passed through an epoch");
+}
+
+double TestVariance(size_t epochs, std::map<uint256, size_t> &histogram) {
+    double variance = 0;
+    double expectation = epochs / histogram.size();
+    for (const auto &match : histogram) {
+        // std::cout << match.first << " : " << match.second << std::endl;
+        variance += (match.second - expectation) * (match.second - expectation);
+    }
+    variance *= histogram.size();
+    variance /= epochs;
+    // std::cout << variance << std::endl;
+
+    return variance;
+}
+
+bool TestRandomEpochHashes(std::vector<std::string> &addressList, size_t epochs,
+                           double threshold) {
+    std::map<uint256, size_t> histogram;
+    // Different epochs produce different results.
+    for (size_t i = 0; i < epochs; i++) {
+        const auto fakeEpochHash = InsecureRand256();
+        const CTxOut output =
+            BuildRandomOutput(addressList, 1, 260 * LOTUS, fakeEpochHash);
+        const auto scriptPubKeyBytes = Hash(ToByteVector(output.scriptPubKey));
+        histogram[scriptPubKeyBytes]++;
+    }
+    return TestVariance(epochs, histogram) > threshold;
+}
+
+bool TestRandomSlots(std::vector<std::string> &addressList, size_t epochs,
+                     double threshold) {
+    std::map<uint256, size_t> histogram;
+    // Different epochs produce different results.
+    for (size_t i = 0; i < epochs; i++) {
+        const auto fakeEpochHash = InsecureRand256();
+        const CTxOut output =
+            BuildRandomOutput(addressList, 1, 260 * LOTUS, fakeEpochHash);
+        const auto scriptPubKeyBytes = Hash(ToByteVector(output.scriptPubKey));
+        histogram[scriptPubKeyBytes]++;
+    }
+    return TestVariance(epochs, histogram) > threshold;
+}
+
+BOOST_AUTO_TEST_CASE(test_randomness) {
+    std::random_device rd;
+    const auto mainNetParams = *CreateChainParams(CBaseChainParams::MAIN);
+    auto gen = [&rd]() { return uint8_t(rd()); };
+
+    // Using 52 epochs for a year to compare hits
+    // The threshold should fail once out of every 1000 tests for these
+    // parameters.
+    // Degrees of freedom tested
+    size_t df = 9;
+    // Test is independent of number of samples. Minimized for speed.
+    const size_t totalEpochsToCheck = 52;
+    const size_t trials = 1000;
+    const double criticalThreshold = 27.877;
+    const uint32_t maxFailures = 2 * trials / 1000;
+    // Generate some addresses
+    std::vector<std::string> addressList;
+    for (size_t i = 0; i < df + 1; i++) {
+        std::vector<uint8_t> fakeKeyBytes(32);
+        std::generate(begin(fakeKeyBytes), end(fakeKeyBytes), gen);
+        const CTxDestination dest = PKHash(Hash160(fakeKeyBytes));
+        addressList.emplace_back(EncodeDestination(dest, mainNetParams));
+    }
+
+    uint32_t failures = 0;
+    for (size_t i = 0; i < trials; i++) {
+        failures += TestRandomEpochHashes(addressList, totalEpochsToCheck,
+                                          criticalThreshold);
+    }
+    BOOST_CHECK_MESSAGE(failures <= maxFailures,
+                        "Uniformity test failed too many times: " << failures);
+
+    failures = 0;
+    for (size_t i = 0; i < trials; i++) {
+        failures +=
+            TestRandomSlots(addressList, totalEpochsToCheck, criticalThreshold);
+    }
+    BOOST_CHECK_MESSAGE(failures <= maxFailures,
+                        "Uniformity test failed too many times: " << failures);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/abc_mining_basic.py
+++ b/test/functional/abc_mining_basic.py
@@ -72,28 +72,14 @@ class AbcMiningRPCTest(BitcoinTestFramework):
         # them are covered in mining_basic.py
         assert_equal(node.getmempoolinfo()['size'], 0)
         share_amount = SUBSIDY * COIN // 26
-        assert_getblocktemplate({
-            'coinbasetxn': {
-                # We expect to see the miner fund addresses in every block
-                'minerfund': {
-                    'outputs': [
-                        {'scriptPubKey': 'a914260617ebf668c9102f71ce24aba97fcaaf9c666a87',
-                        'value': share_amount},
-                        {'scriptPubKey': '76a91407d6f95a81155b7f706d5bc85106fbc77409e36e88ac',
-                        'value': share_amount},
-                        {'scriptPubKey': '76a914ba9113bbb9c6880bb877a284299f21d13365e52888ac',
-                        'value': share_amount},
-                        {'scriptPubKey': '6a1ac8e1f6e5a0ede5f2e3f9a0efeea0ede5aca0e1a0f3e9eeeee5f2',
-                        'value': 10 * share_amount},
-                    ],
-                },
-            },
-            # Although the coinbase value need not necessarily be the same as
-            # the last block due to halvings and fees, we know this to be true
-            # since we are not crossing a halving boundary and there are no
-            # transactions in the mempool.
-            'coinbasevalue': SUBSIDY * COIN,
-        })
+        block_template_data = node.getblocktemplate()
+        print(block_template_data)
+        expected_funding_outputs = 13
+        miner_fund_outputs = block_template_data['coinbasetxn']['minerfund']['outputs']
+        assert_equal(len(miner_fund_outputs), 13)
+        assert_equal(block_template_data['coinbasevalue'], SUBSIDY * COIN)
+        for output in miner_fund_outputs:
+            assert_equal(output['value'], share_amount)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
We've decided to implement a lottocracy for the system of governance on
Lotus. As such, each weak (epoch) a set of random citizens will be
selected to receive a portion of the block reward which they may
allocate however they want. This code implements the random selection
from a list of addresses of verified citizens. This is subject to modulo
bias, however the effect is miner given the use case. In the future,
better algorithms may be implemented.