### PR TITLE
Update unit formating in QT to be 10^8 and Lotus properly

### DIFF
--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -107,7 +107,7 @@ public:
             const QFontMetrics fm(fontMetrics());
             int h = lineEdit()->minimumSizeHint().height();
             int w = GUIUtil::TextWidth(
-                fm, BitcoinUnits::format(BitcoinUnits::BCH,
+                fm, BitcoinUnits::format(BitcoinUnits::LOTUS,
                                          BitcoinUnits::maxMoney(), false,
                                          BitcoinUnits::separatorAlways));
             // Cursor blinking space.
@@ -144,7 +144,7 @@ public:
     }
 
 private:
-    int currentUnit{BitcoinUnits::BCH};
+    int currentUnit{BitcoinUnits::LOTUS};
     Amount singleStep{100000 * SATOSHI};
     mutable QSize cachedMinimumSizeHint;
     bool m_allow_empty{true};

--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -13,18 +13,16 @@ BitcoinUnits::BitcoinUnits(QObject *parent)
 
 QList<BitcoinUnits::Unit> BitcoinUnits::availableUnits() {
     QList<BitcoinUnits::Unit> unitlist;
-    unitlist.append(BCH);
-    unitlist.append(mBCH);
-    unitlist.append(uBCH);
+    unitlist.append(LOTUS);
+    unitlist.append(mLOTUS);
     unitlist.append(SAT);
     return unitlist;
 }
 
 bool BitcoinUnits::valid(int unit) {
     switch (unit) {
-        case BCH:
-        case mBCH:
-        case uBCH:
+        case LOTUS:
+        case mLOTUS:
         case SAT:
             return true;
         default:
@@ -34,12 +32,10 @@ bool BitcoinUnits::valid(int unit) {
 
 QString BitcoinUnits::longName(int unit) {
     switch (unit) {
-        case BCH:
+        case LOTUS:
             return QString(CURRENCY_UNIT.c_str());
-        case mBCH:
+        case mLOTUS:
             return QString("m") + QString(CURRENCY_UNIT.c_str());
-        case uBCH:
-            return QString::fromUtf8("μ") + QString(CURRENCY_UNIT.c_str());
         case SAT:
             return QString("Satoshi (sat)");
         default:
@@ -58,16 +54,13 @@ QString BitcoinUnits::shortName(int unit) {
 
 QString BitcoinUnits::description(int unit) {
     switch (unit) {
-        case BCH:
-            return QString("Bitcoins");
-        case mBCH:
-            return QString("Milli-Bitcoins (1 / 1" THIN_SP_UTF8 "000)");
-        case uBCH:
-            return QString("Micro-Bitcoins (1 / 1" THIN_SP_UTF8
-                           "000" THIN_SP_UTF8 "000)");
+        case LOTUS:
+            return QString("Lotus");
+        case mLOTUS:
+            return QString("Milli-Lotus (1 / 1" THIN_SP_UTF8 "000)");
         case SAT:
-            return QString("Satoshi (sat) (1 / 100" THIN_SP_UTF8
-                           "000" THIN_SP_UTF8 "000)");
+            return QString("Satoshi (sat) (1 / 1" THIN_SP_UTF8 "000" THIN_SP_UTF8
+                           "000)");
         default:
             return QString("???");
     }
@@ -75,12 +68,10 @@ QString BitcoinUnits::description(int unit) {
 
 qint64 BitcoinUnits::factor(int unit) {
     switch (unit) {
-        case BCH:
-            return 100000000;
-        case mBCH:
-            return 100000;
-        case uBCH:
-            return 100;
+        case LOTUS:
+            return 1000000;
+        case mLOTUS:
+            return 1000;
         case SAT:
             return 1;
         default:
@@ -90,12 +81,10 @@ qint64 BitcoinUnits::factor(int unit) {
 
 int BitcoinUnits::decimals(int unit) {
     switch (unit) {
-        case BCH:
-            return 8;
-        case mBCH:
-            return 5;
-        case uBCH:
-            return 2;
+        case LOTUS:
+            return 6;
+        case mLOTUS:
+            return 3;
         case SAT:
             return 0;
         default:

--- a/src/qt/bitcoinunits.h
+++ b/src/qt/bitcoinunits.h
@@ -40,7 +40,7 @@ public:
      * @note Source: https://en.bitcoin.it/wiki/Units.
      * Please add only sensible ones.
      */
-    enum Unit { BCH, mBCH, uBCH, SAT };
+    enum Unit { LOTUS, mLOTUS, SAT };
 
     enum SeparatorStyle { separatorNever, separatorStandard, separatorAlways };
 

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -563,7 +563,7 @@ void CoinControlDialog::updateLabels(CCoinControl &m_coin_control,
     }
 
     // actually update labels
-    int nDisplayUnit = BitcoinUnits::BCH;
+    int nDisplayUnit = BitcoinUnits::LOTUS;
     if (model && model->getOptionsModel()) {
         nDisplayUnit = model->getOptionsModel()->getDisplayUnit();
     }

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -164,7 +164,7 @@ bool parseBitcoinURI(const QString &scheme, const QUrl &uri,
             fShouldReturnFalse = false;
         } else if (i->first == "amount") {
             if (!i->second.isEmpty()) {
-                if (!BitcoinUnits::parse(BitcoinUnits::BCH, i->second,
+                if (!BitcoinUnits::parse(BitcoinUnits::SAT, i->second,
                                          &rv.amount)) {
                     return false;
                 }
@@ -207,7 +207,7 @@ QString formatBitcoinURI(const CChainParams &params,
     if (info.amount != Amount::zero()) {
         ret +=
             QString("?amount=%1")
-                .arg(BitcoinUnits::format(BitcoinUnits::BCH, info.amount, false,
+                .arg(BitcoinUnits::format(BitcoinUnits::LOTUS, info.amount, false,
                                           BitcoinUnits::separatorNever));
         paramCount++;
     }

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -72,7 +72,7 @@ void OptionsModel::Init(bool resetSettings) {
 
     // Display
     if (!settings.contains("nDisplayUnit")) {
-        settings.setValue("nDisplayUnit", BitcoinUnits::BCH);
+        settings.setValue("nDisplayUnit", BitcoinUnits::LOTUS);
     }
     nDisplayUnit = settings.value("nDisplayUnit").toInt();
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -28,7 +28,7 @@ class TxViewDelegate : public QAbstractItemDelegate {
 public:
     explicit TxViewDelegate(const PlatformStyle *_platformStyle,
                             QObject *parent = nullptr)
-        : QAbstractItemDelegate(parent), unit(BitcoinUnits::BCH),
+        : QAbstractItemDelegate(parent), unit(BitcoinUnits::LOTUS),
           platformStyle(_platformStyle) {}
 
     inline void paint(QPainter *painter, const QStyleOptionViewItem &option,

--- a/src/qt/test/uritests.cpp
+++ b/src/qt/test/uritests.cpp
@@ -40,7 +40,7 @@ void URITests::uriTestsCashAddr() {
     QVERIFY(rv.amount == Amount::zero());
 
     uri.setUrl(QString(
-        "bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a?amount=0.001"));
+        "bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a?amount=100000"));
     QVERIFY(GUIUtil::parseBitcoinURI(scheme, uri, &rv));
     QVERIFY(rv.address ==
             QString("bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a"));
@@ -48,15 +48,15 @@ void URITests::uriTestsCashAddr() {
     QVERIFY(rv.amount == 100000 * SATOSHI);
 
     uri.setUrl(QString(
-        "bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a?amount=1.001"));
+        "bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a?amount=1001000"));
     QVERIFY(GUIUtil::parseBitcoinURI(scheme, uri, &rv));
     QVERIFY(rv.address ==
             QString("bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a"));
     QVERIFY(rv.label == QString());
-    QVERIFY(rv.amount == 100100000 * SATOSHI);
+    QVERIFY(rv.amount == 1001000 * SATOSHI);
 
     uri.setUrl(QString(
-        "bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a?amount=100&"
+        "bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a?amount=10000000000&"
         "label=Wikipedia Example"));
     QVERIFY(GUIUtil::parseBitcoinURI(scheme, uri, &rv));
     QVERIFY(rv.address ==

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -164,7 +164,7 @@ void TestGUI(interfaces::Node &node) {
         int unit = walletModel.getOptionsModel()->getDisplayUnit();
         Amount balance = walletModel.wallet().getBalance();
         QString balanceComparison = BitcoinUnits::formatWithUnit(
-            unit, balance, false, BitcoinUnits::separatorAlways);
+            unit, balance, false, BitcoinUnits::separatorNever);
         QCOMPARE(balanceText, balanceComparison);
     }
 
@@ -228,7 +228,7 @@ void TestGUI(interfaces::Node &node) {
                     -1);
             QVERIFY(paymentTextList.at(2).indexOf(QString("Address:")) != -1);
             QCOMPARE(paymentTextList.at(3),
-                     QString("Amount: 0.00000001 ") +
+                     QString("Amount: 0.000001 ") +
                          QString::fromStdString(CURRENCY_UNIT));
             QCOMPARE(paymentTextList.at(4), QString("Label: TEST_LABEL_1"));
             QCOMPARE(paymentTextList.at(5), QString("Message: TEST_MESSAGE_1"));


### PR DESCRIPTION
The QT Wallet uses completely different formatters from the rest of
the codebase and was missed during the previous re-denomination patch.
This commit changes the QT wallet to use the 10^6 base unit, and ensures
the QT wallet uses the appropriate formats.