### PR TITLE
Add `enableMinerFund` to config to enable testing

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -8,7 +8,8 @@
 #include <consensus/consensus.h> // DEFAULT_MAX_BLOCK_SIZE
 
 GlobalConfig::GlobalConfig()
-    : useCashAddr(false), nMaxBlockSize(DEFAULT_MAX_BLOCK_SIZE) {}
+    : useCashAddr(false), enableMinerFund(MinerFundStatus::Unset),
+      nMaxBlockSize(DEFAULT_MAX_BLOCK_SIZE) {}
 
 bool GlobalConfig::SetMaxBlockSize(uint64_t maxBlockSize) {
     // Do not allow maxBlockSize to be set below historic 1MB limit
@@ -42,14 +43,26 @@ bool GlobalConfig::UseCashAddrEncoding() const {
     return useCashAddr;
 }
 
+void GlobalConfig::SetEnableMinerFund(bool c) {
+    enableMinerFund = c ? MinerFundStatus::Enabled : MinerFundStatus::Disabled;
+}
+bool GlobalConfig::EnableMinerFund() const {
+    return enableMinerFund == MinerFundStatus::Unset
+               ? GetChainParams().GetConsensus().enableMinerFund
+               : enableMinerFund == MinerFundStatus::Enabled;
+}
+
 DummyConfig::DummyConfig()
-    : chainParams(CreateChainParams(CBaseChainParams::REGTEST)) {}
+    : chainParams(CreateChainParams(CBaseChainParams::REGTEST)),
+      enableMinerFund(chainParams->GetConsensus().enableMinerFund) {}
 
 DummyConfig::DummyConfig(std::string net)
-    : chainParams(CreateChainParams(net)) {}
+    : chainParams(CreateChainParams(net)),
+      enableMinerFund(chainParams->GetConsensus().enableMinerFund) {}
 
 DummyConfig::DummyConfig(std::unique_ptr<CChainParams> chainParamsIn)
-    : chainParams(std::move(chainParamsIn)) {}
+    : chainParams(std::move(chainParamsIn)),
+      enableMinerFund(chainParams->GetConsensus().enableMinerFund) {}
 
 void DummyConfig::SetChainParams(std::string net) {
     chainParams = CreateChainParams(net);
@@ -61,4 +74,11 @@ void GlobalConfig::SetExcessUTXOCharge(Amount fee) {
 
 Amount GlobalConfig::GetExcessUTXOCharge() const {
     return excessUTXOCharge;
+}
+
+void DummyConfig::SetEnableMinerFund(bool c) {
+    enableMinerFund = c;
+}
+bool DummyConfig::EnableMinerFund() const {
+    return enableMinerFund;
 }

--- a/src/config.h
+++ b/src/config.h
@@ -26,9 +26,19 @@ public:
 
     virtual void SetExcessUTXOCharge(Amount amt) = 0;
     virtual Amount GetExcessUTXOCharge() const = 0;
+
+    virtual void SetEnableMinerFund(bool) = 0;
+    virtual bool EnableMinerFund() const = 0;
 };
 
 class GlobalConfig final : public Config {
+private:
+    enum class MinerFundStatus {
+        Unset = 0,
+        Enabled = 1,
+        Disabled = 0,
+    };
+
 public:
     GlobalConfig();
     bool SetMaxBlockSize(uint64_t maxBlockSize) override;
@@ -40,8 +50,12 @@ public:
     void SetExcessUTXOCharge(Amount) override;
     Amount GetExcessUTXOCharge() const override;
 
+    void SetEnableMinerFund(bool) override;
+    bool EnableMinerFund() const override;
+
 private:
     bool useCashAddr;
+    MinerFundStatus enableMinerFund;
     Amount excessUTXOCharge;
 
     /** The largest block size this node will accept. */
@@ -66,8 +80,12 @@ public:
     void SetExcessUTXOCharge(Amount amt) override {}
     Amount GetExcessUTXOCharge() const override { return Amount::zero(); }
 
+    void SetEnableMinerFund(bool) override;
+    bool EnableMinerFund() const override;
+
 private:
     std::unique_ptr<CChainParams> chainParams;
+    bool enableMinerFund;
 };
 
 // Temporary woraround.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2802,6 +2802,11 @@ bool AppInitMain(Config &config, RPCServer &rpcServer,
     // We do this by default to avoid confusion with BTC addresses.
     config.SetCashAddrEncoding(args.GetBoolArg("-usecashaddr", true));
 
+    // Hidden Flag: Enable validation and addition of miner funding addresses
+    // for testing purposes
+    config.SetEnableMinerFund(args.GetBoolArg(
+        "-enableminerfund", chainparams.GetConsensus().enableMinerFund));
+
     // Step 8: load indexers
     if (args.GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
         g_txindex = std::make_unique<TxIndex>(nTxIndexCache, false, fReindex);

--- a/src/miner.h
+++ b/src/miner.h
@@ -161,6 +161,7 @@ private:
     const CChainParams &chainParams;
 
     const CTxMemPool &m_mempool;
+    bool enableMinerFund;
 
 public:
     struct Options {
@@ -168,6 +169,7 @@ public:
         uint64_t nExcessiveBlockSize;
         uint64_t nMaxGeneratedBlockSize;
         CFeeRate blockMinFeeRate;
+        bool enableMinerFund;
     };
 
     BlockAssembler(const Config &config, const CTxMemPool &mempool);

--- a/src/minerfund.cpp
+++ b/src/minerfund.cpp
@@ -25,12 +25,12 @@ static const CTxOut BurnOutput(const Amount amount) {
 }
 
 std::vector<CTxOut> GetMinerFundRequiredOutputs(const Consensus::Params &params,
+                                                const bool enableMinerFund,
                                                 const CBlockIndex *pindexPrev,
                                                 const Amount &blockReward) {
-    if (!gArgs.GetBoolArg("-enableminerfund", params.enableMinerFund)) {
+    if (!enableMinerFund) {
         return {};
     }
-
     const Amount shareAmount = blockReward / 26;
 
     return {

--- a/src/minerfund.h
+++ b/src/minerfund.h
@@ -18,6 +18,7 @@ struct Params;
 }
 
 std::vector<CTxOut> GetMinerFundRequiredOutputs(const Consensus::Params &params,
+                                                const bool enableMinerFund,
                                                 const CBlockIndex *pindexPrev,
                                                 const Amount &blockReward);
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -953,8 +953,9 @@ static UniValue getblocktemplate(const Config &config,
     UniValue aux(UniValue::VOBJ);
 
     UniValue requiredOutputsList(UniValue::VARR);
-    for (auto requiredOutput : GetMinerFundRequiredOutputs(
-             consensusParams, pindexPrev, coinbasevalue)) {
+    for (auto requiredOutput :
+         GetMinerFundRequiredOutputs(consensusParams, config.EnableMinerFund(),
+                                     pindexPrev, coinbasevalue)) {
         UniValue requiredOutputObj(UniValue::VOBJ);
         requiredOutputObj.pushKV("scriptPubKey",
                                  HexStr(requiredOutput.scriptPubKey));

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -67,7 +67,7 @@ static bool CheckFilterLookups(BlockFilterIndex &filter_index,
 CBlock BuildChainTestingSetup::CreateBlock(
     const CBlockIndex *prev, const std::vector<CMutableTransaction> &txns,
     const CScript &scriptPubKey) {
-    const Config &config = GetConfig();
+    const Config &config = DummyConfig();
     std::unique_ptr<CBlockTemplate> pblocktemplate =
         BlockAssembler(config, *m_node.mempool).CreateNewBlock(scriptPubKey);
     CBlock &block = pblocktemplate->block;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -148,7 +148,7 @@ std::set<int> setDirtyFileInfo;
 
 BlockValidationOptions::BlockValidationOptions(const Config &config)
     : excessiveBlockSize(config.GetMaxBlockSize()), checkPoW(true),
-      checkMerkleRoot(true) {}
+      checkMerkleRoot(true), enableMinerFund(config.EnableMinerFund()) {}
 
 CBlockIndex *LookupBlockIndex(const BlockHash &hash) {
     AssertLockHeld(cs_main);
@@ -1902,7 +1902,8 @@ bool CChainState::ConnectBlock(const CBlock &block, BlockValidationState &state,
     }
 
     const std::vector<CTxOut> requiredOutputs = GetMinerFundRequiredOutputs(
-        consensusParams, pindex->pprev, blockReward);
+        consensusParams, options.shouldValidateMinerFund(), pindex->pprev,
+        blockReward);
 
     if (!requiredOutputs.empty()) {
         auto nextRequiredOutput = requiredOutputs.begin();

--- a/src/validation.h
+++ b/src/validation.h
@@ -14,8 +14,8 @@
 #include <amount.h>
 #include <blockfileinfo.h>
 #include <blockindexworkcomparator.h>
-#include <coins.h>
 #include <chain.h>
+#include <coins.h>
 #include <consensus/consensus.h>
 #include <disconnectresult.h>
 #include <flatfile.h>
@@ -183,15 +183,18 @@ private:
     uint64_t excessiveBlockSize;
     bool checkPoW : 1;
     bool checkMerkleRoot : 1;
+    bool enableMinerFund : 1;
 
 public:
     // Do full validation by default
     explicit BlockValidationOptions(const Config &config);
     explicit BlockValidationOptions(uint64_t _excessiveBlockSize,
                                     bool _checkPow = true,
-                                    bool _checkMerkleRoot = true)
+                                    bool _checkMerkleRoot = true,
+                                    bool _enableMinerFund = true)
         : excessiveBlockSize(_excessiveBlockSize), checkPoW(_checkPow),
-          checkMerkleRoot(_checkMerkleRoot) {}
+          checkMerkleRoot(_checkMerkleRoot), enableMinerFund(_enableMinerFund) {
+    }
 
     BlockValidationOptions withCheckPoW(bool _checkPoW = true) const {
         BlockValidationOptions ret = *this;
@@ -206,9 +209,16 @@ public:
         return ret;
     }
 
+    BlockValidationOptions withMinerFund(bool _enableMinerFund = true) const {
+        BlockValidationOptions ret = *this;
+        ret.enableMinerFund = _enableMinerFund;
+        return ret;
+    }
+
     bool shouldValidatePoW() const { return checkPoW; }
     bool shouldValidateMerkleRoot() const { return checkMerkleRoot; }
     uint64_t getExcessiveBlockSize() const { return excessiveBlockSize; }
+    bool shouldValidateMinerFund() const { return enableMinerFund; }
 };
 
 /**


### PR DESCRIPTION
This commit adds `enableMinerFund` to the config so that it can be
overriden in w/o setting gArgs. It also adds flags to the
`BlockAssembler` options as well as the validation options in order to
support passing these configs down to the appropriate code. However,
current testing setup relies on the global `GetConfig()` singleton. This
singleton always returns the chainparams from the global `Params()`
singleton function. The testing setup changes the Params after
initialization, thus we need to ensure that `EnableMinerFund()` returns
the appropriate default consensus parameter if it has not been formally
set by the command line or the testing setup. In the future, global
singletons should be removed so that tests can be ran in parallel.
However, this requires substantial refactors to the entire codebase to
ensure proper initialization ordering and encapsulation of
functionality.