### PR TITLE
Allow minerfunding to be disabled on mainet/testnet

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -32,11 +32,13 @@ public:
 };
 
 class GlobalConfig final : public Config {
-private:
+    friend class GlobalConfigTest;
+
+public:
     enum class MinerFundStatus {
         Unset = 0,
         Enabled = 1,
-        Disabled = 0,
+        Disabled = 3,
     };
 
 public:

--- a/src/test/config_tests.cpp
+++ b/src/test/config_tests.cpp
@@ -11,6 +11,14 @@
 
 #include <boost/test/unit_test.hpp>
 
+class GlobalConfigTest {
+public:
+    GlobalConfig::MinerFundStatus
+    GetInternalMinerFund(const GlobalConfig &config) {
+        return config.enableMinerFund;
+    }
+};
+
 BOOST_FIXTURE_TEST_SUITE(config_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(max_block_size) {
@@ -57,6 +65,19 @@ BOOST_AUTO_TEST_CASE(chain_params) {
 
     SelectParams(CBaseChainParams::REGTEST);
     BOOST_CHECK_EQUAL(&Params(), &config.GetChainParams());
+}
+
+BOOST_AUTO_TEST_CASE(enable_miner_fund) {
+    GlobalConfig config;
+
+    // Test enable miner fund.
+    // Minerfund should be whatever consensus is before manual setting.
+    BOOST_CHECK_EQUAL(config.EnableMinerFund(),
+                      config.GetChainParams().GetConsensus().enableMinerFund);
+    config.SetEnableMinerFund(false);
+    BOOST_CHECK_EQUAL(config.EnableMinerFund(), false);
+    config.SetEnableMinerFund(true);
+    BOOST_CHECK_EQUAL(config.EnableMinerFund(), true);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -284,7 +284,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity) {
     // Note that by default, these tests run with size accounting enabled.
     GlobalConfig config;
     // Don't check this functionality in this test.
-    config.SetEnableMinerFund(false);
+    config.SetEnableMinerFund(true);
     const CChainParams &chainparams = config.GetChainParams();
     CScript scriptPubKey =
         CScript() << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909"


### PR DESCRIPTION
Currently, minerfund is only allowed to be enabled on regtest. This
commit allows it do be disabled on mainnet and testnet, as well as in
unit tests.