### PR TITLE
Remove 1650 byte scriptSig limit

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -84,10 +84,6 @@ bool IsStandardTx(const CTransaction &tx, bool permit_bare_multisig,
     }
 
     for (const CTxIn &txin : tx.vin) {
-        if (txin.scriptSig.size() > MAX_TX_IN_SCRIPT_SIG_SIZE) {
-            reason = "scriptsig-size";
-            return false;
-        }
         // Coinbase can have non-pushonly scriptSig
         if (!tx.IsCoinBase() && !txin.scriptSig.IsPushOnly()) {
             reason = "scriptsig-not-pushonly";

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -33,16 +33,6 @@ static const Amount DEFAULT_BLOCK_MIN_TX_FEE_PER_KB(1000 * SATOSHI);
 static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
 
 /**
- * Biggest 'standard' txin is a 15-of-15 P2SH multisig with compressed
- * keys (remember the 520 byte limit on redeemScript size). That works
- * out to a (15*(33+1))+3=513 byte redeemScript, 513+1+15*(73+1)+3=1627
- * bytes of scriptSig, which we round off to 1650 bytes for some minor
- * future-proofing. That's also enough to spend a 20-of-20 CHECKMULTISIG
- * scriptPubKey, though such a scriptPubKey is not considered standard.
- */
-static const unsigned int MAX_TX_IN_SCRIPT_SIG_SIZE = 1650;
-
-/**
  * Default for -maxmempool, maximum megabytes of mempool memory usage.
  */
 static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -860,18 +860,17 @@ BOOST_AUTO_TEST_CASE(test_IsStandard) {
     BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
     BOOST_CHECK_EQUAL(reason, "scriptpubkey");
 
-    // Check large scriptSig (non-standard if size is >1650 bytes)
+    // Check that large scriptSig is allowed
     t.vout.resize(1);
     t.vout[0].nValue = MAX_MONEY;
     t.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key.GetPubKey()));
     // OP_PUSHDATA2 with len (3 bytes) + data (1647 bytes) = 1650 bytes
     t.vin[0].scriptSig = CScript() << std::vector<uint8_t>(1647, 0); // 1650
     BOOST_CHECK(IsStandardTx(CTransaction(t), reason));
-
     t.vin[0].scriptSig = CScript() << std::vector<uint8_t>(1648, 0); // 1651
-    reason.clear();
-    BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
-    BOOST_CHECK_EQUAL(reason, "scriptsig-size");
+    BOOST_CHECK(IsStandardTx(CTransaction(t), reason));
+    t.vin[0].scriptSig = CScript() << std::vector<uint8_t>(9997, 0); // 1651
+    BOOST_CHECK(IsStandardTx(CTransaction(t), reason));
 
     // Check scriptSig format (non-standard if there are any other ops than just
     // PUSHs)

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -323,15 +323,6 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
             rawtxs=[ToHex(tx)],
         )
         tx = FromHex(CTransaction(), raw_tx_reference)
-        # Some too large scriptSig (>1650 bytes)
-        tx.vin[0].scriptSig = CScript([b'a' * 1648])
-        tx.calc_txid()
-        self.check_mempool_result(
-            result_expected=[{'txid': tx.txid_hex, 'allowed': False,
-                              'reject-reason': 'scriptsig-size'}],
-            rawtxs=[tx.serialize().hex()],
-        )
-        tx = FromHex(CTransaction(), raw_tx_reference)
         output_p2sh_burn = CTxOut(nValue=540, scriptPubKey=CScript(
             [OP_HASH160, hash160(b'burn'), OP_EQUAL]))
         # Use enough outputs to make the tx too large for our policy
@@ -389,6 +380,17 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
                               'reject-reason': 'non-BIP68-final'}],
             rawtxs=[tx.serialize().hex()],
             maxfeerate=0,
+        )
+
+        tx = FromHex(CTransaction(), raw_tx_reference)
+        # script too large (10'001 bytes)
+        tx.vin[0].scriptSig = CScript(b'\0' * 10001)
+        tx.calc_txid()
+        self.check_mempool_result(
+            result_expected=[{'txid': tx.txid_hex,
+                              'allowed': False, 
+                              'reject-reason': 'mandatory-script-verify-flag-failed (Script is too big)'}],
+            rawtxs=[tx.serialize().hex()],
         )
 
 


### PR DESCRIPTION
Now the limit is the general 10000 byte script limit.

Through larger opcode limits and the addition of Taproot, smart contracts might require more bytes as inputs.

There is no DoS vector, since each byte has to be paid for, and there are cheaper ways to generate lots of bytes (e.g. OP_NUM2BIN/OP_3DUP). Quadratic hashing is also not of concern anymore.