### PR TITLE
Ensure rpc_generateblock always passes

### DIFF
--- a/test/functional/rpc_generateblock.py
+++ b/test/functional/rpc_generateblock.py
@@ -66,7 +66,7 @@ class GenerateBlockTest(BitcoinTestFramework):
             node.sendtoaddress(address, 0.1)
 
         self.log.info('Generate block with txid')
-        txid = node.sendtoaddress(address, 1)
+        txid = node.sendtoaddress(address, 100)
         hash = node.generateblock(address, [txid])['hash']
         block = node.getblock(hash, 1)
         assert_equal(len(block['tx']), 2)


### PR DESCRIPTION
While redenominating the code to 10^6 from 10^8, this particular
spot was missed. The test continued to pass because `listunspent` is
nondeterministic. Sometimes it was pulling a tx with sufficient funds,
and sometimes it was creating transactions that overspent. This change
ensures that both transactions that can be used in subsequent lines
have enough funds to pass the test.