### PR TITLE
Remove BCHA seeders in prep for testnet and mainnet launches

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -140,17 +140,6 @@ public:
         // all service bits wanted by any release ASAP to avoid it where
         // possible.
         // Bitcoin ABC seeder
-        vSeeds.emplace_back("seed.bitcoinabc.org");
-        // BU backed seeder
-        vSeeds.emplace_back("btccash-seeder.bitcoinunlimited.info");
-        // Jason B. Cox
-        vSeeds.emplace_back("seeder.jasonbcox.com");
-        // Amaury SÉCHET
-        vSeeds.emplace_back("seed.deadalnix.me");
-        // BCHD
-        vSeeds.emplace_back("seed.bchd.cash");
-        // Fabien
-        vSeeds.emplace_back("seeder.fabien.cash");
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<uint8_t>(1, 0);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<uint8_t>(1, 5);
@@ -256,15 +245,6 @@ public:
 
         vFixedSeeds.clear();
         vSeeds.clear();
-        // nodes with support for servicebits filtering should be at the top
-        // Bitcoin ABC seeder
-        vSeeds.emplace_back("testnet-seed.bitcoinabc.org");
-        // Amaury SÉCHET
-        vSeeds.emplace_back("testnet-seed.deadalnix.me");
-        // BCHD
-        vSeeds.emplace_back("testnet-seed.bchd.cash");
-        // Fabien
-        vSeeds.emplace_back("testnet-seeder.fabien.cash");
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<uint8_t>(1, 111);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<uint8_t>(1, 196);


### PR DESCRIPTION
As per title. These seeders won't register or provide Lotus nodes to
us. We will need to setup our own seeders and add them here later.