### PR TITLE
[tests] Ensure block height is correct in tests

### DIFF
--- a/test/functional/abc-invalid-chains.py
+++ b/test/functional/abc-invalid-chains.py
@@ -40,8 +40,7 @@ class InvalidChainsTest(BitcoinTestFramework):
         coinbase = create_coinbase(height, CScript([self.counter]))
         coinbase.rehash()
         self.counter += 1
-        block = create_block(base_block_hash, coinbase, block_time)
-        block.nHeight = height
+        block = create_block(base_block_hash, coinbase, height, block_time)
         prepare_block(block)
         self.tip = block
         self.block_heights[block.sha256] = height

--- a/test/functional/abc-mempool-coherence-on-activations.py
+++ b/test/functional/abc-mempool-coherence-on-activations.py
@@ -146,8 +146,7 @@ class MempoolCoherenceOnActivationsTest(BitcoinTestFramework):
         height = self.block_heights[base_block_hash] + 1
         coinbase = create_coinbase(height)
         coinbase.rehash()
-        block = create_block(base_block_hash, coinbase, block_time)
-        block.nHeight = height
+        block = create_block(base_block_hash, coinbase, height, block_time)
         prepare_block(block)
 
         # Do PoW, which is cheap on regnet

--- a/test/functional/abc-minimaldata.py
+++ b/test/functional/abc-minimaldata.py
@@ -86,8 +86,7 @@ class MinimaldataTest(BitcoinTestFramework):
         block_time = (parent.nTime + 1) if nTime is None else nTime
 
         block = create_block(
-            parent.sha256, create_coinbase(block_height), block_time)
-        block.nHeight = block_height
+            parent.sha256, create_coinbase(block_height), block_height, block_time)
         block.vtx.extend(transactions)
         prepare_block(block)
         block.solve()

--- a/test/functional/abc-replay-protection.py
+++ b/test/functional/abc-replay-protection.py
@@ -77,8 +77,7 @@ class ReplayProtectionTest(BitcoinTestFramework):
         height = self.block_heights[base_block_hash] + 1
         coinbase = create_coinbase(height)
         coinbase.rehash()
-        block = create_block(base_block_hash, coinbase, block_time)
-        block.nHeight = height
+        block = create_block(base_block_hash, coinbase, height, block_time)
         prepare_block(block)
         self.tip = block
         self.block_heights[block.sha256] = height

--- a/test/functional/abc-schnorr.py
+++ b/test/functional/abc-schnorr.py
@@ -101,8 +101,7 @@ class SchnorrTest(BitcoinTestFramework):
         block_time = (parent.nTime + 1) if nTime is None else nTime
 
         block = create_block(
-            parent.sha256, create_coinbase(block_height), block_time)
-        block.nHeight = block_height
+            parent.sha256, create_coinbase(block_height), block_height, block_time)
         block.vtx.extend(transactions)
         prepare_block(block)
         self.block_heights[block.sha256] = block_height

--- a/test/functional/abc-schnorrmultisig.py
+++ b/test/functional/abc-schnorrmultisig.py
@@ -104,8 +104,7 @@ class SchnorrMultisigTest(BitcoinTestFramework):
         block_time = (parent.nTime + 1) if nTime is None else nTime
 
         block = create_block(
-            parent.sha256, create_coinbase(block_height), block_time)
-        block.nHeight = block_height
+            parent.sha256, create_coinbase(block_height), block_height, block_time)
         block.vtx.extend(transactions)
         prepare_block(block)
         block.solve()

--- a/test/functional/abc-sync-chain.py
+++ b/test/functional/abc-sync-chain.py
@@ -49,8 +49,7 @@ class SyncChainTest(BitcoinTestFramework):
 
         blocks = []
         for i in range(NUM_IBD_BLOCKS * 2):
-            block = create_block(tip, create_coinbase(height), time)
-            block.nHeight = height
+            block = create_block(tip, create_coinbase(height), height, time)
             prepare_block(block)
             blocks.append(block)
             tip = block.sha256

--- a/test/functional/abc-transaction-ordering.py
+++ b/test/functional/abc-transaction-ordering.py
@@ -67,12 +67,12 @@ class TransactionOrderingTest(BitcoinTestFramework):
         coinbase.rehash()
         if spend is None:
             # We need to have something to spend to fill the block.
-            block = create_block(base_block_hash, coinbase, block_time)
+            block = create_block(base_block_hash, coinbase, height, block_time)
         else:
             # Burn half of the fees
             coinbase.vout[0].nValue += spend.tx.vout[spend.n].nValue // 2
             coinbase.rehash()
-            block = create_block(base_block_hash, coinbase, block_time)
+            block = create_block(base_block_hash, coinbase, height, block_time)
 
             # Make sure we have plenty enough to spend going forward.
             spendable_outputs = deque([spend])
@@ -117,7 +117,6 @@ class TransactionOrderingTest(BitcoinTestFramework):
         if tx_count > 0:
             assert_equal(len(block.vtx), tx_count)
 
-        block.nHeight = height
         block.update_size()
         block.rehash_extended_metadata()
         block.solve()

--- a/test/functional/abc_mining_basic.py
+++ b/test/functional/abc_mining_basic.py
@@ -73,7 +73,6 @@ class AbcMiningRPCTest(BitcoinTestFramework):
         assert_equal(node.getmempoolinfo()['size'], 0)
         share_amount = SUBSIDY * COIN // 26
         block_template_data = node.getblocktemplate()
-        print(block_template_data)
         expected_funding_outputs = 13
         miner_fund_outputs = block_template_data['coinbasetxn']['minerfund']['outputs']
         assert_equal(len(miner_fund_outputs), 13)

--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -179,13 +179,13 @@ class ExampleTest(BitcoinTestFramework):
         height = self.nodes[0].getblockcount()
 
         for i in range(10):
+            height += 1
             # Use the mininode and blocktools functionality to manually build a block
             # Calling the generate() rpc is easier, but this allows us to exactly
             # control the blocks and transactions.
             block = create_block(
                 self.tip, create_coinbase(
-                    height + 1), self.block_time)
-            block.nHeight = height + 1
+                    height), height, self.block_time)
             prepare_block(block)
             block_message = msg_block(block)
             # Send message is used to send a P2P message to the node over our
@@ -194,7 +194,6 @@ class ExampleTest(BitcoinTestFramework):
             self.tip = block.sha256
             blocks.append(self.tip)
             self.block_time += 1
-            height += 1
 
         self.log.info(
             "Wait for node1 to reach current tip (height 11) using RPC")

--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -122,8 +122,7 @@ class AssumeValidTest(BitcoinTestFramework):
         # Create the first block with a coinbase output to our key
         height = 1
         block = create_block(self.tip, create_coinbase(
-            height, coinbase_pubkey), self.block_time)
-        block.nHeight = height
+            height, coinbase_pubkey), height, self.block_time)
         self.blocks.append(block)
         self.block_time += 1
         prepare_block(block)
@@ -135,8 +134,7 @@ class AssumeValidTest(BitcoinTestFramework):
         # Bury the block 100 deep so the coinbase output is spendable
         for i in range(100):
             block = create_block(
-                self.tip, create_coinbase(height), self.block_time)
-            block.nHeight = height
+                self.tip, create_coinbase(height), height, self.block_time)
             prepare_block(block)
             self.blocks.append(block)
             self.tip = block.sha256
@@ -153,8 +151,7 @@ class AssumeValidTest(BitcoinTestFramework):
         tx.rehash()
 
         block102 = create_block(
-            self.tip, create_coinbase(height), self.block_time)
-        block102.nHeight = height
+            self.tip, create_coinbase(height), height, self.block_time)
         self.block_time += 1
         block102.vtx.extend([tx])
         prepare_block(block102)
@@ -166,8 +163,7 @@ class AssumeValidTest(BitcoinTestFramework):
         # Bury the assumed valid block 3400 deep
         for i in range(3700):
             block = create_block(
-                self.tip, create_coinbase(height), self.block_time)
-            block.nHeight = height
+                self.tip, create_coinbase(height), height, self.block_time)
             prepare_block(block)
             self.blocks.append(block)
             self.tip = block.sha256

--- a/test/functional/feature_bip68_sequence.py
+++ b/test/functional/feature_bip68_sequence.py
@@ -396,8 +396,7 @@ class BIP68Test(BitcoinTestFramework):
             self.nodes[0].getblockcount() - 1), 16)
         height = self.nodes[0].getblockcount()
         for i in range(2):
-            block = create_block(tip, create_coinbase(height), cur_time)
-            block.nHeight = height
+            block = create_block(tip, create_coinbase(height), height, cur_time)
             prepare_block(block)
             tip = block.sha256
             height += 1

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -117,8 +117,7 @@ class BIP65Test(BitcoinTestFramework):
         tip = self.nodes[0].getbestblockhash()
         block_time = self.nodes[0].getblockheader(tip)['mediantime'] + 1
         block = create_block(int(tip, 16), create_coinbase(
-            CLTV_HEIGHT - 1), block_time)
-        block.nHeight = CLTV_HEIGHT - 1
+            CLTV_HEIGHT - 1), CLTV_HEIGHT,  block_time)
         block.vtx.append(fundtx)
         # include the -1 CLTV in block
         block.vtx.append(spendtx)
@@ -130,8 +129,7 @@ class BIP65Test(BitcoinTestFramework):
         
         # Create valid block to get over the threshold for the version enforcement
         block = create_block(int(tip, 16), create_coinbase(
-            CLTV_HEIGHT - 1), block_time)
-        block.nHeight = CLTV_HEIGHT - 1
+            CLTV_HEIGHT - 1), CLTV_HEIGHT - 1, block_time)
         prepare_block(block)
         self.nodes[0].p2p.send_and_ping(msg_block(block))
 
@@ -139,8 +137,7 @@ class BIP65Test(BitcoinTestFramework):
         block_time += 1
         self.log.info(
             "Test that invalid-according-to-cltv transactions cannot appear in a block")
-        block = create_block(tip, create_coinbase(CLTV_HEIGHT), block_time)
-        block.nHeight = CLTV_HEIGHT
+        block = create_block(tip, create_coinbase(CLTV_HEIGHT), CLTV_HEIGHT, block_time)
 
         fundtx = create_transaction(self.nodes[0], self.coinbase_txids[1],
                                     self.nodeaddress, amount=SUBSIDY - Decimal('1'), vout=1)
@@ -178,8 +175,7 @@ class BIP65Test(BitcoinTestFramework):
         tip = block.hash
         block_time += 1
         block = create_block(
-            block.sha256, create_coinbase(CLTV_HEIGHT + 1), block_time)
-        block.nHeight = CLTV_HEIGHT + 1
+            block.sha256, create_coinbase(CLTV_HEIGHT + 1), CLTV_HEIGHT + 1, block_time)
         block.vtx.append(spendtx)
         prepare_block(block)
 

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -201,9 +201,8 @@ class BIP68_112_113Test(BitcoinTestFramework):
 
     def create_test_block(self, txs):
         block = create_block(self.tip, create_coinbase(
-            self.tipheight + 1), self.last_block_time + 600)
+            self.tipheight + 1), self.tipheight + 1, self.last_block_time + 600)
         block.vtx.extend(txs)
-        block.nHeight = self.tipheight + 1
         prepare_block(block)
         return block
 

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -59,8 +59,7 @@ class BIP66Test(BitcoinTestFramework):
         tip = self.nodes[0].getbestblockhash()
         block_time = self.nodes[0].getblockheader(tip)['mediantime'] + 1
         block = create_block(
-            int(tip, 16), create_coinbase(DERSIG_HEIGHT), block_time)
-        block.nHeight = DERSIG_HEIGHT
+            int(tip, 16), create_coinbase(DERSIG_HEIGHT), DERSIG_HEIGHT, block_time)
         spendtx = create_transaction(self.nodes[0], self.coinbase_txids[1],
                                      self.nodeaddress, amount=1.0, vout=1)
         unDERify(spendtx)

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -153,7 +153,7 @@ class PruneTest(BitcoinTestFramework):
 
         # Wait for blk00000.dat to be pruned
         wait_until(lambda: not os.path.isfile(
-            os.path.join(self.prunedir, "blk00000.dat")), timeout=30)
+            os.path.join(self.prunedir, "blk00000.dat")), timeout=120)
 
         self.log.info("Success")
         usage = calc_usage(self.prunedir)

--- a/test/functional/logos_enforce_standard_consensus.py
+++ b/test/functional/logos_enforce_standard_consensus.py
@@ -76,8 +76,7 @@ class EnforceStandardConsensusTest(BitcoinTestFramework):
             coinbase.vout[1].scriptPubKey = p2sh_script
             coinbase.rehash()
             block = create_block(
-                int(parent_block_header['hash'], 16), coinbase, parent_block_header['time'] + 1)
-            block.nHeight = height
+                int(parent_block_header['hash'], 16), coinbase, height, parent_block_header['time'] + 1)
             return block
 
         # make a few non-standard txs

--- a/test/functional/logos_feature_int63.py
+++ b/test/functional/logos_feature_int63.py
@@ -86,8 +86,7 @@ class Int63Test(BitcoinTestFramework):
             coinbase.vout[1].scriptPubKey = p2sh_script
             coinbase.rehash()
             block = create_block(
-                int(parent_block_header['hash'], 16), coinbase, parent_block_header['time'] + 1)
-            block.nHeight = height
+                int(parent_block_header['hash'], 16), coinbase, height, parent_block_header['time'] + 1)
             return block
 
         interesting_numbers = [

--- a/test/functional/logos_feature_minerfund.py
+++ b/test/functional/logos_feature_minerfund.py
@@ -66,8 +66,7 @@ class MinerFundTest(BitcoinTestFramework):
         coinbase.vout[1].nValue = int(SUBSIDY * COIN)
         coinbase.rehash()
         block = create_block(int(best_block_hash, 16),
-                             coinbase, block_time + 1)
-        block.nHeight = block_height
+                             coinbase, block_height, block_time + 1)
         prepare_block(block)
         assert_equal(node.submitblock(ToHex(block)), 'bad-cb-minerfund')
 
@@ -83,8 +82,7 @@ class MinerFundTest(BitcoinTestFramework):
         coinbase.vout[2], coinbase.vout[4] = coinbase.vout[4], coinbase.vout[2]
         coinbase.rehash()
         block = create_block(int(best_block_hash, 16),
-                             coinbase, block_time + 1)
-        block.nHeight = block_height
+                             coinbase, block_height, block_time + 1)
         prepare_block(block)
         assert_equal(node.submitblock(ToHex(block)), 'bad-cb-minerfund')
 
@@ -92,9 +90,8 @@ class MinerFundTest(BitcoinTestFramework):
         coinbase.vout[2], coinbase.vout[4] = coinbase.vout[4], coinbase.vout[2]
         coinbase.rehash()
         block = create_block(int(best_block_hash, 16),
-                             coinbase, block_time + 1)
+                             coinbase, block_height, block_time + 1)
 
-        block.nHeight = block_height
         prepare_block(block)
         assert_equal(node.submitblock(ToHex(block)), None)
 
@@ -119,8 +116,7 @@ class MinerFundTest(BitcoinTestFramework):
                                         CScript(bytes.fromhex(output['scriptPubKey']))))
         coinbase.rehash()
         block = create_block(int(best_block_hash, 16),
-                             coinbase, best_block_header['time'] + 1)
-        block.nHeight = block_height
+                             coinbase, block_height, best_block_header['time'] + 1)
         block.vtx.append(tx)
         prepare_block(block)
         assert_equal(node.submitblock(ToHex(block)), None)

--- a/test/functional/mempool_updatefromblock.py
+++ b/test/functional/mempool_updatefromblock.py
@@ -25,7 +25,7 @@ class MempoolUpdateFromBlockTest(BitcoinTestFramework):
 
     def transaction_graph_test(self, size, n_tx_to_mine=None,
                                start_input_txid='', end_address='',
-                               fee=Decimal(0.00100000)):
+                               fee=Decimal(0.100000)):
         """Create an acyclic tournament (a type of directed graph) of
         transactions and use it for testing.
 
@@ -42,7 +42,6 @@ class MempoolUpdateFromBlockTest(BitcoinTestFramework):
 
         More details: https://en.wikipedia.org/wiki/Tournament_(graph_theory)
         """
-
         if not start_input_txid:
             start_input_txid = self.nodes[0].getblock(
                 self.nodes[0].getblockhash(1))['tx'][0]
@@ -58,9 +57,9 @@ class MempoolUpdateFromBlockTest(BitcoinTestFramework):
             self.log.debug('Preparing transaction #{}...'.format(i))
             # Prepare inputs.
             if i == 0:
-                inputs = [{'txid': start_input_txid, 'vout': 0}]
+                inputs = [{'txid': start_input_txid, 'vout': 1}]
                 inputs_value = self.nodes[0].gettxout(
-                    start_input_txid, 0)['value']
+                    start_input_txid, 1)['value']
             else:
                 inputs = []
                 inputs_value = 0

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -150,8 +150,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         tip = node.getbestblockhash()
         mtp = node.getblockheader(tip)['mediantime']
         block = create_block(
-            int(tip, 16), create_coinbase(height), mtp + 1)
-        block.nHeight = height
+            int(tip, 16), create_coinbase(height), height, mtp + 1)
         prepare_block(block)
         return block
 

--- a/test/functional/p2p_fingerprint.py
+++ b/test/functional/p2p_fingerprint.py
@@ -36,8 +36,7 @@ class P2PFingerprintTest(BitcoinTestFramework):
         for _ in range(nblocks):
             coinbase = create_coinbase(prev_height + 1)
             block_time = prev_median_time + 1
-            block = create_block(int(prev_hash, 16), coinbase, block_time)
-            block.nHeight = prev_height + 1
+            block = create_block(int(prev_hash, 16), coinbase, prev_height + 1, block_time)
             prepare_block(block)
 
             blocks.append(block)

--- a/test/functional/p2p_invalid_block.py
+++ b/test/functional/p2p_invalid_block.py
@@ -45,8 +45,7 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
         self.log.info("Create a new block with an anyone-can-spend coinbase")
 
         height = 1
-        block = create_block(tip, create_coinbase(height), block_time)
-        block.nHeight = height
+        block = create_block(tip, create_coinbase(height), height, block_time)
         prepare_block(block)
         # Save the coinbase for later
         block1 = block
@@ -70,8 +69,7 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
         # src/consensus/merkle.cpp.
         self.log.info("Test merkle root malleability.")
 
-        block2 = create_block(tip, create_coinbase(height), block_time)
-        block2.nHeight = height
+        block2 = create_block(tip, create_coinbase(height), height, block_time)
         block_time += 1
 
         # b'0x51' is OP_TRUE
@@ -113,8 +111,7 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
 
         self.log.info("Test very broken block.")
 
-        block3 = create_block(tip, create_coinbase(height), block_time)
-        block3.nHeight = height
+        block3 = create_block(tip, create_coinbase(height), height,  block_time)
         block_time += 1
         block3.vtx[0].vout[0].nValue = int(2 * SUBSIDY * COIN)  # Too high!
         block3.vtx[0].rehash()
@@ -139,8 +136,7 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
 
         # Complete testing of CVE-2018-17144, by checking for the inflation bug.
         # Create a block that spends the output of a tx in a previous block.
-        block4 = create_block(tip, create_coinbase(height), block_time)
-        block4.nHeight = height
+        block4 = create_block(tip, create_coinbase(height), height, block_time)
         tx3 = create_tx_with_script(tx2, 0, script_sig=b'\x51',
                                     amount=int(SUBSIDY * COIN))
 

--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -73,8 +73,7 @@ class InvalidTxRequestTest(BitcoinTestFramework):
         height = 1
         blocks = []
         for _ in invalid_txs.iter_all_templates():
-            block = create_block(tip, create_coinbase(height), block_time)
-            block.nHeight = height
+            block = create_block(tip, create_coinbase(height), height, block_time)
             prepare_block(block)
             block_time = block.nTime + 1
             height += 1

--- a/test/functional/p2p_sendheaders.py
+++ b/test/functional/p2p_sendheaders.py
@@ -269,7 +269,7 @@ class SendHeadersTest(BitcoinTestFramework):
             "Verify getheaders with null locator and invalid hashstop does not return headers.")
         height = tip["height"] + 1
         block = create_block(int(tip["hash"], 16), create_coinbase(height),
-            tip["mediantime"] + 1)
+            height, tip["mediantime"] + 1)
         block.nHeight = height
         prepare_block(block)
         test_node.send_header_for_blocks([block])
@@ -314,9 +314,8 @@ class SendHeadersTest(BitcoinTestFramework):
                 last_time = self.nodes[0].getblock(
                     self.nodes[0].getbestblockhash())['time']
                 block_time = last_time + 1
-                new_block = create_block(
-                    tip, create_coinbase(height + 1), block_time)
-                new_block.nHeight = height + 1
+                new_block = create_block(tip, create_coinbase(height + 1),
+                    height + 1, block_time)
                 prepare_block(new_block)
                 test_node.send_header_for_blocks([new_block])
                 test_node.wait_for_getdata([new_block.sha256])
@@ -356,8 +355,7 @@ class SendHeadersTest(BitcoinTestFramework):
                 blocks = []
                 for b in range(i + 1):
                     blocks.append(create_block(
-                        tip, create_coinbase(height), block_time))
-                    blocks[-1].nHeight = height
+                        tip, create_coinbase(height), height, block_time))
                     prepare_block(blocks[-1])
                     tip = blocks[-1].sha256
                     block_time += 1
@@ -480,8 +478,7 @@ class SendHeadersTest(BitcoinTestFramework):
         blocks = []
         for b in range(2):
             blocks.append(create_block(
-                tip, create_coinbase(height), block_time))
-            blocks[-1].nHeight = height
+                tip, create_coinbase(height), height, block_time))
             prepare_block(blocks[-1])
             tip = blocks[-1].sha256
             block_time += 1
@@ -500,8 +497,7 @@ class SendHeadersTest(BitcoinTestFramework):
         blocks = []
         for b in range(3):
             blocks.append(create_block(
-                tip, create_coinbase(height), block_time))
-            blocks[-1].nHeight = height
+                tip, create_coinbase(height), height, block_time))
             prepare_block(blocks[-1])
             tip = blocks[-1].sha256
             block_time += 1
@@ -524,8 +520,7 @@ class SendHeadersTest(BitcoinTestFramework):
         # Create extra blocks for later
         for b in range(20):
             blocks.append(create_block(
-                tip, create_coinbase(height), block_time))
-            blocks[-1].nHeight = height
+                tip, create_coinbase(height), height, block_time))
             prepare_block(blocks[-1])
             tip = blocks[-1].sha256
             block_time += 1
@@ -575,8 +570,7 @@ class SendHeadersTest(BitcoinTestFramework):
             # Create two more blocks.
             for j in range(2):
                 blocks.append(create_block(
-                    tip, create_coinbase(height), block_time))
-                blocks[-1].nHeight = height
+                    tip, create_coinbase(height), height, block_time))
                 prepare_block(blocks[-1])
                 tip = blocks[-1].sha256
                 block_time += 1
@@ -599,8 +593,7 @@ class SendHeadersTest(BitcoinTestFramework):
         MAX_UNCONNECTING_HEADERS = 10
         for j in range(MAX_UNCONNECTING_HEADERS + 1):
             blocks.append(create_block(
-                tip, create_coinbase(height), block_time))
-            blocks[-1].nHeight = height
+                tip, create_coinbase(height), height, block_time))
             prepare_block(blocks[-1])
             tip = blocks[-1].sha256
             block_time += 1

--- a/test/functional/p2p_tx_download.py
+++ b/test/functional/p2p_tx_download.py
@@ -98,7 +98,7 @@ class TxDownloadTest(BitcoinTestFramework):
             inputs=[{
                 # coinbase
                 "txid": self.nodes[0].getblock(self.nodes[0].getblockhash(1))['tx'][0],
-                "vout": 0
+                "vout": 1
             }],
             outputs={ADDRESS_BCHREG_UNSPENDABLE: SUBSIDY - Decimal('0.025')},
         )
@@ -107,11 +107,11 @@ class TxDownloadTest(BitcoinTestFramework):
             privkeys=[self.nodes[0].get_deterministic_priv_key().key],
         )['hex']
         ctx = FromHex(CTransaction(), tx)
-        txid = int(ctx.rehash(), 16)
+        ctx.rehash()
 
         self.log.info(
             "Announce the transaction to all nodes from all {} incoming peers, but never send it".format(NUM_INBOUND))
-        msg = msg_inv([CInv(t=MSG_TX, h=txid)])
+        msg = msg_inv([CInv(t=MSG_TX, h=ctx.txid)])
         for p in self.peers:
             p.send_and_ping(msg)
 

--- a/test/functional/p2p_unrequested_blocks.py
+++ b/test/functional/p2p_unrequested_blocks.py
@@ -113,8 +113,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         block_time = int(time.time()) + 1
         for i in range(2):
             blocks_h2.append(create_block(
-                tips[i], create_coinbase(2), block_time))
-            blocks_h2[i].nHeight = 2
+                tips[i], create_coinbase(2), 2, block_time))
             prepare_block(blocks_h2[i])
             block_time += 1
         test_node.send_and_ping(msg_block(blocks_h2[0]))
@@ -127,8 +126,7 @@ class AcceptBlockTest(BitcoinTestFramework):
 
         # 3. Send another block that builds on genesis.
         block_h1f = create_block(
-            int("0x" + self.nodes[0].getblockhash(0), 0), create_coinbase(1), block_time)
-        block_h1f.nHeight = 1
+            int("0x" + self.nodes[0].getblockhash(0), 0), create_coinbase(1), 1, block_time)
         prepare_block(block_h1f)
         block_time += 1
         test_node.send_and_ping(msg_block(block_h1f))
@@ -144,8 +142,7 @@ class AcceptBlockTest(BitcoinTestFramework):
 
         # 4. Send another two block that build on the fork.
         block_h2f = create_block(
-            block_h1f.sha256, create_coinbase(2), block_time)
-        block_h2f.nHeight = 2
+            block_h1f.sha256, create_coinbase(2), 2, block_time)
         prepare_block(block_h2f)
         block_time += 1
         test_node.send_and_ping(msg_block(block_h2f))
@@ -165,8 +162,7 @@ class AcceptBlockTest(BitcoinTestFramework):
 
         # 4b. Now send another block that builds on the forking chain.
         block_h3 = create_block(
-            block_h2f.sha256, create_coinbase(3), block_h2f.nTime + 1)
-        block_h3.nHeight = 3
+            block_h2f.sha256, create_coinbase(3), 3, block_h2f.nTime + 1)
         prepare_block(block_h3)
         test_node.send_and_ping(msg_block(block_h3))
 
@@ -192,8 +188,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         for i in range(288):
             height = i + 4
             next_block = create_block(
-                tip.sha256, create_coinbase(i + 4), tip.nTime + 1)
-            next_block.nHeight = height
+                tip.sha256, create_coinbase(height), height, tip.nTime + 1)
             prepare_block(next_block)
             all_blocks.append(next_block)
             tip = next_block
@@ -271,26 +266,22 @@ class AcceptBlockTest(BitcoinTestFramework):
         # 8. Create a chain which is invalid at a height longer than the
         # current chain, but which has more blocks on top of that
         block_289f = create_block(
-            all_blocks[284].sha256, create_coinbase(289), all_blocks[284].nTime + 1)
-        block_289f.nHeight = 289
+            all_blocks[284].sha256, create_coinbase(289), 289, all_blocks[284].nTime + 1)
         prepare_block(block_289f)
 
         block_290f = create_block(
-            block_289f.sha256, create_coinbase(290), block_289f.nTime + 1)
-        block_290f.nHeight = 290
+            block_289f.sha256, create_coinbase(290), 290, block_289f.nTime + 1)
         prepare_block(block_290f)
 
         block_291 = create_block(
-            block_290f.sha256, create_coinbase(291), block_290f.nTime + 1)
-        block_291.nHeight = 291
+            block_290f.sha256, create_coinbase(291), 291, block_290f.nTime + 1)
         # block_291 spends a coinbase below maturity!
         block_291.vtx.append(create_tx_with_script(
             block_290f.vtx[0], 0, script_sig=b"42", amount=1))
         prepare_block(block_291)
 
         block_292 = create_block(
-            block_291.sha256, create_coinbase(292), block_291.nTime + 1)
-        block_292.nHeight = 292
+            block_291.sha256, create_coinbase(292), 292, block_291.nTime + 1)
         prepare_block(block_292)
 
         # Now send all the headers on the chain and enough blocks to trigger
@@ -341,8 +332,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         # Now send a new header on the invalid chain, indicating we're forked
         # off, and expect to get disconnected
         block_293 = create_block(
-            block_292.sha256, create_coinbase(293), block_292.nTime + 1)
-        block_293.nHeight = 293
+            block_292.sha256, create_coinbase(293), 293, block_292.nTime + 1)
         prepare_block(block_293)
         headers_message = msg_headers()
         headers_message.headers.append(CBlockHeader(block_293))

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -332,8 +332,7 @@ class BlockchainTest(BitcoinTestFramework):
         b20 = node.getblock(b20hash)
 
         def solve_and_send_block(prevhash, height, time):
-            b = create_block(prevhash, create_coinbase(height), time)
-            b.nHeight = height
+            b = create_block(prevhash, create_coinbase(height), height, time)
             prepare_block(b)
             node.p2p.send_and_ping(msg_block(b))
             return b

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -28,6 +28,7 @@ from .messages import (
     CTxOut,
     FromHex,
     ToHex,
+    hash256,
 )
 from .txtools import pad_tx
 from .util import assert_equal, satoshi_round
@@ -37,7 +38,7 @@ TIME_GENESIS_BLOCK = 1600000000
 SUBSIDY = Decimal('260')
 
 
-def create_block(hashprev, coinbase, ntime=None, *, version=1):
+def create_block(hashprev, coinbase, height, ntime=None, *, version=1):
     """Create a block (with regtest difficulty)."""
     block = CBlock()
     block.nHeaderVersion = version
@@ -46,6 +47,7 @@ def create_block(hashprev, coinbase, ntime=None, *, version=1):
         block.nTime = int(time.time() + 600)
     else:
         block.nTime = ntime
+    block.nHeight = height
     block.hashPrevBlock = hashprev
     # difficulty retargeting is disabled in REGTEST chainparams
     block.nBits = 0x207fffff

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -523,6 +523,9 @@ class CTransaction:
         txid_bytes = hash256(r)
         self.txid_hex = txid_bytes[::-1].hex()
         self.txid = uint256_from_str(txid_bytes)
+    
+    def is_coinbase(self):
+        return self.vin[0].prevout.hash == 0
 
     def input_merkle_root(self):
         hashes = []

--- a/test/functional/wallet_resendwallettransactions.py
+++ b/test/functional/wallet_resendwallettransactions.py
@@ -52,8 +52,7 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         node.setmocktime(block_time)
         height = node.getblockcount() + 1
         block = create_block(int(node.getbestblockhash(), 16), create_coinbase(
-            height), block_time)
-        block.nHeight = height
+            height), height, block_time)
         prepare_block(block)
         node.submitblock(ToHex(block))
 


### PR DESCRIPTION
When adding the height to the block header, many tests were updated
explicitly to set this field. However, this wasn't done for all tests
and missed. This commit added height to the `create_block` signature of
the blocktools function in tests, and updates the tests to provide it
as part of the parameters. Additionally, it gets the metadata so that
the blocks are always valid.