### PR TITLE
Fix lotus seeder checkpoints height

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -260,6 +260,8 @@ public:
         vFixedSeeds.clear();
         vSeeds.clear();
 
+        vSeeds.emplace_back("seeder.abcpay.cash");
+
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<uint8_t>(1, 111);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<uint8_t>(1, 196);
         base58Prefixes[SECRET_KEY] = std::vector<uint8_t>(1, 239);

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -260,8 +260,6 @@ public:
         vFixedSeeds.clear();
         vSeeds.clear();
 
-        vSeeds.emplace_back("seeder.abcpay.cash");
-
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<uint8_t>(1, 111);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<uint8_t>(1, 196);
         base58Prefixes[SECRET_KEY] = std::vector<uint8_t>(1, 239);

--- a/src/seeder/bitcoin.cpp
+++ b/src/seeder/bitcoin.cpp
@@ -61,8 +61,10 @@ PeerMessagingState CSeederNode::ProcessMessage(std::string strCommand,
         // nVersion);
         if (vAddr) {
             MessageWriter::WriteMessage(vSend, NetMsgType::GETADDR);
-            std::vector<BlockHash> locatorHash(
-                1, Params().Checkpoints().mapCheckpoints.rbegin()->second);
+            std::vector<BlockHash> locatorHash(0);
+            if (Params().Checkpoints().mapCheckpoints.size() >= 2) {
+                locatorHash = std::vector<BlockHash>(1, Params().Checkpoints().mapCheckpoints.rbegin()->second);
+            }
             MessageWriter::WriteMessage(vSend, NetMsgType::GETHEADERS,
                                         CBlockLocator(locatorHash), uint256());
             doneAfter = GetTime() + GetTimeout();

--- a/src/seeder/bitcoin.cpp
+++ b/src/seeder/bitcoin.cpp
@@ -62,7 +62,7 @@ PeerMessagingState CSeederNode::ProcessMessage(std::string strCommand,
         if (vAddr) {
             MessageWriter::WriteMessage(vSend, NetMsgType::GETADDR);
             std::vector<BlockHash> locatorHash(0);
-            if (Params().Checkpoints().mapCheckpoints.size() >= 2) {
+            if (Params().Checkpoints().mapCheckpoints.size() > 0) {
                 locatorHash = std::vector<BlockHash>(1, Params().Checkpoints().mapCheckpoints.rbegin()->second);
             }
             MessageWriter::WriteMessage(vSend, NetMsgType::GETHEADERS,

--- a/src/seeder/db.h
+++ b/src/seeder/db.h
@@ -26,7 +26,11 @@
 #define REQUIRE_VERSION 70001
 
 static inline int GetRequireHeight() {
-    return Params().Checkpoints().mapCheckpoints.rbegin()->first;
+    if (Params().Checkpoints().mapCheckpoints.rbegin() !=
+        Params().Checkpoints().mapCheckpoints.rend()) {
+        return Params().Checkpoints().mapCheckpoints.rbegin()->first;
+    }
+    return 0;
 }
 
 static inline std::string ToString(const CService &ip) {


### PR DESCRIPTION
Hi @schancel,

 I try to implement the fix for the seeder but I got some issues:
* When running the seeder on a vps, it can only crawl the directly connected node, not the other nodes.
* Even though the nslookup returns the node's addresses (I can see it while debugging), but no data is sync for lotusd (with config: dnsseed=1, connect=1)

My DNS config for the domain abcpay.cash is:

| Type | Host | Value |
|----------|----------|---|
| A Record | seeder | 167.179.88.165 |
| NS Record | dnsseed | seeder.abcpay.cash |

The command I ran the dnsseed is:
```
 sudo ./lotus-seeder -ns=seeder.abcpay.cash -mbox=test@gmail.com -chain=test -host=dnsseed.abcpay.cash -port=53
```

Could you help to check?

Thanks!