### PR TITLE
Update Exodus upgrade activation time

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -103,8 +103,8 @@ public:
         consensus.defaultAssumeValid =
             ChainParamsConstants::MAINNET_DEFAULT_ASSUME_VALID;
 
-        // Nov 15, 2021 12:00:00 UTC protocol upgrade
-        consensus.selectronActivationTime = 1636977600;
+        // 2021-12-21T15:59:00.000Z protocol upgrade
+        consensus.exodusActivationTime = 1640102340;
 
         /**
          * The message start string is designed to be unlikely to occur in
@@ -224,8 +224,8 @@ public:
         consensus.defaultAssumeValid =
             ChainParamsConstants::TESTNET_DEFAULT_ASSUME_VALID;
 
-        // Nov 15, 2021 12:00:00 UTC protocol upgrade
-        consensus.selectronActivationTime = 1636977600;
+        // 2021-12-21T15:59:00.000Z protocol upgrade
+        consensus.exodusActivationTime = 1640102340;
 
         // "ltdk" with MSB set
         diskMagic[0] = 0xec;
@@ -322,8 +322,8 @@ public:
         // valid.
         consensus.defaultAssumeValid = BlockHash();
 
-        // Nov 15, 2021 12:00:00 UTC protocol upgrade
-        consensus.selectronActivationTime = 1636977600;
+        // 2021-12-21T15:59:00.000Z protocol upgrade
+        consensus.exodusActivationTime = 1640102340;
 
         // "lrdk" with MSB set
         diskMagic[0] = 0xec;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -20,8 +20,8 @@ namespace Consensus {
 struct Params {
     BlockHash hashGenesisBlock;
     int nSubsidyHalvingInterval;
-    /** Unix time used for MTP activation of 15 Nov 2021 12:00:00 UTC upgrade */
-    int selectronActivationTime;
+    /** Unix time used for MTP activation of 2021-12-21T15:59:00.000Z protocol upgrade */
+    int exodusActivationTime;
 
     /**
      * Don't warn about unknown BIP 9 activations below this height.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -285,7 +285,7 @@ bool CheckSequenceLocks(const CTxMemPool &pool, const CTransaction &tx,
 static bool IsReplayProtectionEnabled(const Consensus::Params &params,
                                       int64_t nMedianTimePast) {
     return nMedianTimePast >= gArgs.GetArg("-replayprotectionactivationtime",
-                                           params.selectronActivationTime);
+                                           params.exodusActivationTime);
 }
 
 static bool IsReplayProtectionEnabled(const Consensus::Params &params,


### PR DESCRIPTION
Updating activation time to winter solstice 2021:
  2021-12-21T15:59:00.000Z

Obtained timing from: https://www.weather.gov/media/ind/seasons.pdf