### PR TITLE
Fix ticker symbol check in `abc_rpc_ecash.py`

### DIFF
--- a/test/functional/abc_rpc_ecash.py
+++ b/test/functional/abc_rpc_ecash.py
@@ -53,7 +53,7 @@ class ECashRPCTest(BitcoinTestFramework):
         # is adapted to XEC only.
         # In BCHA mode, it triggers a "-fallbackfee is set very high!" error.
         self.restart_node(0, ["-ecash=0", "-fallbackfee=0"])
-        self.test_currency(ticker="Lotus",
+        self.test_currency(ticker="XPI",
                            satoshis_per_unit=1_000_000,
                            decimals=6)
 


### PR DESCRIPTION
Was missed due to other test failures during the merge ov v0.23.6.
This adjust the expectation to pass properly.