### PR TITLE
Allow mainnet XAddresses to be input into QT address fields

### DIFF
--- a/src/qt/bitcoinaddressvalidator.cpp
+++ b/src/qt/bitcoinaddressvalidator.cpp
@@ -65,7 +65,7 @@ QValidator::State BitcoinAddressEntryValidator::validate(QString &input,
         int ch = input.at(idx).unicode();
 
         if ((ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'z') ||
-            (ch >= 'A' && ch <= 'Z') || (ch == ':')) {
+            (ch >= 'A' && ch <= 'Z') || (ch == ':') || (ch == '_')) {
             // Alphanumeric and not a 'forbidden' character
             // We also include ':' for cashaddr.
         } else {

--- a/src/qt/test/bitcoinaddressvalidatortests.cpp
+++ b/src/qt/test/bitcoinaddressvalidatortests.cpp
@@ -53,4 +53,8 @@ void BitcoinAddressValidatorTests::inputTests() {
     // Only alphanumeric chars are accepted.
     in = "%";
     QVERIFY(v.validate(in, unused) == QValidator::Invalid);
+
+    // valid characters, invalid address
+    in = "lotus_poop";
+    QVERIFY(v.validate(in, unused) == QValidator::Acceptable);
 }


### PR DESCRIPTION
We overlooked that on mainnet underscore characters are part of the
address. The validation of the address fields in QT don't currently
allow underscores. This commit adds them to the list of valid characters
so that we can use the QT interfaces to send and receive mainnet Lotus.