### PR TITLE
Bump version to 1.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_USER_MAKE_RULES_OVERRIDE
 )
 
 project(lotus
-	VERSION 1.0.0
+	VERSION 1.0.1
 	DESCRIPTION "Lotus is a full node implementation of the Lotus protocol."
 	HOMEPAGE_URL "https://www.givelotus.org"
 )

--- a/contrib/aur/lotus-qt/PKGBUILD
+++ b/contrib/aur/lotus-qt/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Josh Ellithorpe <quest@mac.com>
 
 pkgname=lotus-qt
-pkgver=1.0.0
+pkgver=1.0.1
 pkgrel=0
 pkgdesc="Lotus with lotusd, lotus-cli, lotus-tx, lotus-seeder and lotus-qt"
 arch=('i686' 'x86_64')

--- a/contrib/aur/lotus/PKGBUILD
+++ b/contrib/aur/lotus/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Josh Ellithorpe <quest@mac.com>
 
 pkgname=lotusd
-pkgver=1.0.0
+pkgver=1.0.1
 pkgrel=0
 pkgdesc="Lotus with lotusd, lotus-tx, lotus-seeder and lotus-cli"
 arch=('i686' 'x86_64')


### PR DESCRIPTION
* Fixes a problem with the seeder segfaulting when there are no
  checkpoints.
* Fixes the input dialog validation to allow lotus mainnet addresses.