### PR TITLE
Fix commitment in XAddress check byte hash calculation

### DIFF
--- a/src/qt/test/guiutiltests.cpp
+++ b/src/qt/test/guiutiltests.cpp
@@ -42,7 +42,7 @@ void GUIUtilTests::toCurrentEncodingTest() {
     // garbage in, garbage out
     QVERIFY(GUIUtil::convertToXAddress(params, "garbage") == "garbage");
 
-    QString lotus_pubkey = "lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ";
+    QString lotus_pubkey = "lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQQnQTHN";
     QString cashaddr_pubkey =
         "ecash:qpm2qsznhks23z7629mms6s4cwef74vcwva87rkuu2";
     QVERIFY(GUIUtil::convertToXAddress(params, cashaddr_pubkey) ==

--- a/src/qt/test/uritests.cpp
+++ b/src/qt/test/uritests.cpp
@@ -19,81 +19,81 @@ void URITests::uriTestsLotus() {
     QString scheme = QString("payto");
     QUrl uri;
     uri.setUrl(QString(
-        "lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ?req-dontexist="));
+        "lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQQnQTHN?req-dontexist="));
     QVERIFY(!GUIUtil::parseBitcoinURI(scheme, uri, &rv));
 
     uri.setUrl(QString(
-        "payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ?dontexist="));
+        "payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQQnQTHN?dontexist="));
     QVERIFY(GUIUtil::parseBitcoinURI(scheme, uri, &rv));
     QVERIFY(rv.address ==
-            QString("lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ"));
+            QString("lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQQnQTHN"));
     QVERIFY(rv.label == QString());
     QVERIFY(rv.amount == Amount::zero());
 
     uri.setUrl(
-        QString("payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ?label="
+        QString("payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQQnQTHN?label="
                 "Wikipedia Example Address"));
     QVERIFY(GUIUtil::parseBitcoinURI(scheme, uri, &rv));
     QVERIFY(rv.address ==
-            QString("lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ"));
+            QString("lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQQnQTHN"));
     QVERIFY(rv.label == QString("Wikipedia Example Address"));
     QVERIFY(rv.amount == Amount::zero());
 
     uri.setUrl(QString(
-        "payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ?amount=100000"));
+        "payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQQnQTHN?amount=100000"));
     QVERIFY(GUIUtil::parseBitcoinURI(scheme, uri, &rv));
     QVERIFY(rv.address ==
-            QString("lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ"));
+            QString("lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQQnQTHN"));
     QVERIFY(rv.label == QString());
     QVERIFY(rv.amount == 100000 * LOTUS);
 
-    uri.setUrl(QString("payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ?"
+    uri.setUrl(QString("payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQQnQTHN?"
                        "amount=1001000"));
     QVERIFY(GUIUtil::parseBitcoinURI(scheme, uri, &rv));
     QVERIFY(rv.address ==
-            QString("lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ"));
+            QString("lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQQnQTHN"));
     QVERIFY(rv.label == QString());
     QVERIFY(rv.amount == 1001000 * LOTUS);
 
-    uri.setUrl(QString("payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ?"
+    uri.setUrl(QString("payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQQnQTHN?"
                        "amount=100000000&"
                        "label=Wikipedia Example"));
     QVERIFY(GUIUtil::parseBitcoinURI(scheme, uri, &rv));
     QVERIFY(rv.address ==
-            QString("lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ"));
+            QString("lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQQnQTHN"));
     QVERIFY(rv.amount == int64_t(100000000) * LOTUS);
     QVERIFY(rv.label == QString("Wikipedia Example"));
 
     uri.setUrl(
-        QString("payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ?message="
+        QString("payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQQnQTHN?message="
                 "Wikipedia Example Address"));
     QVERIFY(GUIUtil::parseBitcoinURI(scheme, uri, &rv));
     QVERIFY(rv.address ==
-            QString("lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ"));
+            QString("lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQQnQTHN"));
     QVERIFY(rv.label == QString());
 
     QVERIFY(GUIUtil::parseBitcoinURI(
         scheme,
         "payto://"
-        "lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ?"
+        "lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQQnQTHN?"
         "message=Wikipedia Example Address",
         &rv));
     QVERIFY(rv.address ==
-            QString("lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ"));
+            QString("lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQQnQTHN"));
     QVERIFY(rv.label == QString());
 
     uri.setUrl(QString(
-        "payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ?req-message="
+        "payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQQnQTHN?req-message="
         "Wikipedia Example Address"));
     QVERIFY(GUIUtil::parseBitcoinURI(scheme, uri, &rv));
 
     uri.setUrl(QString(
-        "payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ?amount=1000000,"
+        "payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQQnQTHN?amount=1000000,"
         "000&label=Wikipedia Example"));
     QVERIFY(!GUIUtil::parseBitcoinURI(scheme, uri, &rv));
 
     uri.setUrl(QString(
-        "payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ?amount=1000000,"
+        "payto:lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQQnQTHN?amount=1000000,"
         "000.0&label=Wikipedia Example"));
     QVERIFY(!GUIUtil::parseBitcoinURI(scheme, uri, &rv));
 }
@@ -146,7 +146,7 @@ void URITests::uriTestsCashAddr() {
     QVERIFY(GUIUtil::parseBitcoinURI(scheme, uri, &rv));
     QVERIFY(rv.address ==
             QString("ecash:qpm2qsznhks23z7629mms6s4cwef74vcwva87rkuu2"));
-                std::cout << rv.amount;
+    std::cout << rv.amount;
     QVERIFY(rv.amount == 100 * LOTUS);
     QVERIFY(rv.label == QString("Wikipedia Example"));
 
@@ -191,17 +191,17 @@ void URITests::uriTestFormatURI() {
         r.address = "ecash:qpm2qsznhks23z7629mms6s4cwef74vcwva87rkuu2";
         r.message = "test";
         QString uri = GUIUtil::formatBitcoinURI(*params, r);
-        QVERIFY(uri == "lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ?"
+        QVERIFY(uri == "lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQQnQTHN?"
                        "message=test");
     }
 
     {
         SendCoinsRecipient r;
-        r.address = "lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ";
+        r.address = "lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQQnQTHN";
         r.message = "test";
         QString uri = GUIUtil::formatBitcoinURI(*params, r);
 
-        QVERIFY(uri == "lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ?"
+        QVERIFY(uri == "lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQQnQTHN?"
                        "message=test");
     }
 
@@ -220,7 +220,7 @@ void URITests::uriTestFormatURI() {
         r.address = "12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX";
         r.message = "test";
         QString uri = GUIUtil::formatBitcoinURI(*params, r);
-        QVERIFY(uri == "lotus_16PSJHejVUZd1LPr51EAB4zK1Xi3D5qjQNtNHkof5?"
+        QVERIFY(uri == "lotus_16PSJHejVUZd1LPr51EAB4zK1Xi3D5qjQNtLnv8df?"
                        "message=test");
     }
 }

--- a/src/test/dstencode_tests.cpp
+++ b/src/test/dstencode_tests.cpp
@@ -40,8 +40,9 @@ BOOST_AUTO_TEST_CASE(test_addresses) {
         "ecash:qpm2qsznhks23z7629mms6s4cwef74vcwva87rkuu2";
     std::string cashaddr_script =
         "ecash:ppm2qsznhks23z7629mms6s4cwef74vcwv2zrv3l8h";
-    std::string lotus_pubkey = "lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQLVBwUQ";
-    std::string lotus_script = "lotus_1PrQz5R11Ae1YcbvUpGDSvzPP2GsVw6EDCvZqy";
+    std::string lotus_pubkey =
+        "lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQQnQTHN";
+    std::string lotus_script = "lotus_1PrQz5R11Ae1YcbvUpGDSvzPP2GsVw6E7mthMV";
 
     DummyCashAddrConfig config;
 

--- a/src/test/xaddress_tests.cpp
+++ b/src/test/xaddress_tests.cpp
@@ -240,4 +240,35 @@ BOOST_AUTO_TEST_CASE(encode_destination_works) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(encode_broken_checksum_works) {
+    // Test that we validate addresses that had the old
+    // checksum commitment that include varints for the
+    // size of "lotus" and the payload.
+    GlobalConfig config;
+
+    const std::string encodedAddress =
+        "lotus_16PSJLk9W86KAZp26x3uM176w6N9vUU8YNQQnQTHN";
+    const std::vector<uint8_t> expectedPayload = {
+        118, 169, 20,  118, 160, 64,  83,  189, 160, 168, 139, 218, 81,
+        119, 184, 106, 21,  195, 178, 159, 85,  152, 115, 136, 172};
+    XAddress::Content parsedAddress;
+
+    BOOST_CHECK_EQUAL(XAddress::Decode(encodedAddress, parsedAddress),
+                      XAddress::DECODE_OK);
+    BOOST_CHECK_EQUAL(parsedAddress.m_network, XAddress::MAINNET);
+    BOOST_CHECK_EQUAL(parsedAddress.m_type, XAddress::SCRIPT_PUB_KEY);
+    BOOST_CHECK_MESSAGE(parsedAddress.m_payload == expectedPayload,
+                        "Parsed payload incorrect");
+    BOOST_CHECK_EQUAL(parsedAddress.m_token, XAddress::TOKEN_NAME);
+
+    // Check encodes with correct checksum
+    XAddress::Content oldCheckSumDecoded;
+    BOOST_CHECK_EQUAL(
+        XAddress::Decode("lotus_1PrQxBkWiRorG9kcMKvFq3hoRdN8XLUy4YzAHe",
+                         oldCheckSumDecoded),
+        XAddress::DECODE_OK);
+    BOOST_CHECK_EQUAL(XAddress::Encode(oldCheckSumDecoded),
+                      "lotus_1PrQxBkWiRorG9kcMKvFq3hoRdN8XLUy4YzAHe");
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/util/data/bitcoin-util-test.json
+++ b/test/util/data/bitcoin-util-test.json
@@ -227,7 +227,7 @@
     "exec": "./lotus-tx",
     "args": [
       "-create",
-      "outaddr=100.:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF:garbage"
+      "outaddr=100.:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gpJBpm:garbage"
     ],
     "return_code": 1,
     "error_txt": "error: TX output missing or too many separators",
@@ -260,8 +260,8 @@
       "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
       "in=bf829c6bcf84579331337659d31f89dfd138f7f7785802d5501c92333145ca7c:18",
       "in=22a6f904655d53ae2ff70e701a0bbd90aa3975c0f40bfc6cc996a9049e31cdfc:1",
-      "outaddr=18:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF",
-      "outaddr=400.:lotus_16PSJQYjnqavSN7kQKQCQ29cRFrot99aLLg4iHj7R"
+      "outaddr=18:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gpJBpm",
+      "outaddr=400.:lotus_16PSJQYjnqavSN7kQKQCQ29cRFrot99aLLg2FPcPP"
     ],
     "output_cmp": "txcreate1.hex",
     "description": "Creates a new transaction with three inputs and two outputs"
@@ -274,8 +274,8 @@
       "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
       "in=bf829c6bcf84579331337659d31f89dfd138f7f7785802d5501c92333145ca7c:18",
       "in=22a6f904655d53ae2ff70e701a0bbd90aa3975c0f40bfc6cc996a9049e31cdfc:1",
-      "outaddr=18:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF",
-      "outaddr=400.:lotus_16PSJQYjnqavSN7kQKQCQ29cRFrot99aLLg4iHj7R"
+      "outaddr=18:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gpJBpm",
+      "outaddr=400.:lotus_16PSJQYjnqavSN7kQKQCQ29cRFrot99aLLg2FPcPP"
     ],
     "output_cmp": "txcreate1.json",
     "description": "Creates a new transaction with three inputs and two outputs (output in json)"
@@ -434,7 +434,7 @@
       "in=4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485:0",
       "set=privatekeys:[\"5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf\"]",
       "set=prevtxs:[{\"txid\":\"4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485\",\"vout\":0,\"scriptPubKey\":\"76a91491b24bf9f5288532960ac687abb035127b1d28a588ac\"}]",
-      "outaddr=0.1:lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ze3Ark",
+      "outaddr=0.1:lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ztnecn",
       "sign=ALL|FORKID"
     ],
     "output_cmp": "txcreatesignv1.hex",
@@ -449,7 +449,7 @@
       "in=4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485:0",
       "set=privatekeys:[\"5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf\"]",
       "set=prevtxs:[{\"txid\":\"4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485\",\"vout\":0,\"scriptPubKey\":\"76a91491b24bf9f5288532960ac687abb035127b1d28a588ac\"}]",
-      "outaddr=0.1:lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ze3Ark",
+      "outaddr=0.1:lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ztnecn",
       "sign=ALL|FORKID"
     ],
     "output_cmp": "txcreatesignv1.json",
@@ -462,7 +462,7 @@
       "in=4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485:0",
       "set=privatekeys:[\"5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf\"]",
       "set=prevtxs:[{\"txid\":\"4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485\",\"vout\":0,\"scriptPubKey\":\"76a91491b24bf9f5288532960ac687abb035127b1d28a588ac\"}]",
-      "outaddr=0.1:lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ze3Ark",
+      "outaddr=0.1:lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ztnecn",
       "sign=ALL|FORKID"
     ],
     "output_cmp": "txcreatesignv2.hex",
@@ -475,7 +475,7 @@
       "in=4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485:0",
       "set=privatekeys:[\"5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf\"]",
       "set=prevtxs:[{\"txid\":\"4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485\",\"vout\":0,\"scriptPubKey\":\"76a91491b24bf9f5288532960ac687abb035127b1d28a588ac\"}]",
-      "outaddr=0.1:lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ze3Ark",
+      "outaddr=0.1:lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ztnecn",
       "sign=SINGLE|FORKID"
     ],
     "output_cmp": "txcreatesignv2-single.hex",
@@ -488,7 +488,7 @@
       "in=4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485:0",
       "set=privatekeys:[\"5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf\"]",
       "set=prevtxs:[{\"txid\":\"4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485\",\"vout\":\"0foo\",\"scriptPubKey\":\"76a91491b24bf9f5288532960ac687abb035127b1d28a588ac\"}]",
-      "outaddr=0.1:lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ze3Ark",
+      "outaddr=0.1:lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ztnecn",
       "sign=ALL|FORKID"
     ],
     "return_code": 1,
@@ -502,7 +502,7 @@
       "in=4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485:0",
       "set=privatekeys:[\"5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf\"]",
       "set=prevtxs:[{\"txid\":\"Zd49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59412\",\"vout\":0,\"scriptPubKey\":\"76a91491b24bf9f5288532960ac687abb035127b1d28a588ac\"}]",
-      "outaddr=0.1:lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ze3Ark",
+      "outaddr=0.1:lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ztnecn",
       "sign=ALL|FORKID"
     ],
     "return_code": 1,
@@ -516,7 +516,7 @@
       "in=4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485:0",
       "set=privatekeys:[\"5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf\"]",
       "set=prevtxs:[{\"txid\":\"4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc594\",\"vout\":0,\"scriptPubKey\":\"76a91491b24bf9f5288532960ac687abb035127b1d28a588ac\"}]",
-      "outaddr=0.1:lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ze3Ark",
+      "outaddr=0.1:lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ztnecn",
       "sign=ALL|FORKID"
     ],
     "return_code": 1,
@@ -530,7 +530,7 @@
       "in=4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485:0",
       "set=privatekeys:[\"5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf\"]",
       "set=prevtxs:[{\"txid\":\"4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc5948512\",\"vout\":0,\"scriptPubKey\":\"76a91491b24bf9f5288532960ac687abb035127b1d28a588ac\"}]",
-      "outaddr=0.1:lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ze3Ark",
+      "outaddr=0.1:lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ztnecn",
       "sign=ALL|FORKID"
     ],
     "return_code": 1,
@@ -684,7 +684,7 @@
     "args": [
       "-create",
       "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
-      "outaddr=18:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF",
+      "outaddr=18:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gpJBpm",
       "outdata=400:54686973204f505f52455455524e207472616e73616374696f6e206f7574707574207761732063726561746564206279206d6f646966696564206372656174657261777472616e73616374696f6e2e"
     ],
     "output_cmp": "txcreatedata1.hex",
@@ -697,7 +697,7 @@
       "-create",
       "nversion=1",
       "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
-      "outaddr=18:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF",
+      "outaddr=18:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gpJBpm",
       "outdata=400:54686973204f505f52455455524e207472616e73616374696f6e206f7574707574207761732063726561746564206279206d6f646966696564206372656174657261777472616e73616374696f6e2e"
     ],
     "output_cmp": "txcreatedata1.json",
@@ -708,7 +708,7 @@
     "args": [
       "-create",
       "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
-      "outaddr=18:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF",
+      "outaddr=18:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gpJBpm",
       "outdata=54686973204f505f52455455524e207472616e73616374696f6e206f7574707574207761732063726561746564206279206d6f646966696564206372656174657261777472616e73616374696f6e2e"
     ],
     "output_cmp": "txcreatedata2.hex",
@@ -720,7 +720,7 @@
       "-json",
       "-create",
       "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
-      "outaddr=18:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF",
+      "outaddr=18:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gpJBpm",
       "outdata=54686973204f505f52455455524e207472616e73616374696f6e206f7574707574207761732063726561746564206279206d6f646966696564206372656174657261777472616e73616374696f6e2e"
     ],
     "output_cmp": "txcreatedata2.json",
@@ -731,7 +731,7 @@
     "args": [
       "-create",
       "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0:4294967293",
-      "outaddr=18:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF"
+      "outaddr=18:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gpJBpm"
     ],
     "output_cmp": "txcreatedata_seq0.hex",
     "description": "Creates a new transaction with one input with sequence number and one address output"
@@ -742,7 +742,7 @@
       "-json",
       "-create",
       "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0:4294967293",
-      "outaddr=18:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF"
+      "outaddr=18:lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gpJBpm"
     ],
     "output_cmp": "txcreatedata_seq0.json",
     "description": "Creates a new transaction with one input with sequence number and one address output (output in json)"

--- a/test/util/data/tt-delin1-out.json
+++ b/test/util/data/tt-delin1-out.json
@@ -196,7 +196,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "lotus_16PSJMWtSC9SNZo93u1QKxQk8m17xF9RvZwi8Xoxj"
+                    "lotus_16PSJMWtSC9SNZo93u1QKxQk8m17xF9RvZwgef9eB"
                 ]
             }
         },
@@ -209,7 +209,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "lotus_16PSJLS6tQYrdEhn2rLpBvDqdbrgUADpiAqhUxBcJ"
+                    "lotus_16PSJLS6tQYrdEhn2rLpBvDqdbrgUADpiAqiBVYsY"
                 ]
             }
         }

--- a/test/util/data/tt-delout1-out.json
+++ b/test/util/data/tt-delout1-out.json
@@ -205,7 +205,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "lotus_16PSJMWtSC9SNZo93u1QKxQk8m17xF9RvZwi8Xoxj"
+                    "lotus_16PSJMWtSC9SNZo93u1QKxQk8m17xF9RvZwgef9eB"
                 ]
             }
         }

--- a/test/util/data/tt-locktime317000-out.json
+++ b/test/util/data/tt-locktime317000-out.json
@@ -205,7 +205,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "lotus_16PSJMWtSC9SNZo93u1QKxQk8m17xF9RvZwi8Xoxj"
+                    "lotus_16PSJMWtSC9SNZo93u1QKxQk8m17xF9RvZwgef9eB"
                 ]
             }
         },
@@ -218,7 +218,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "lotus_16PSJLS6tQYrdEhn2rLpBvDqdbrgUADpiAqhUxBcJ"
+                    "lotus_16PSJLS6tQYrdEhn2rLpBvDqdbrgUADpiAqiBVYsY"
                 ]
             }
         }

--- a/test/util/data/txcreate1.json
+++ b/test/util/data/txcreate1.json
@@ -43,7 +43,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF"
+                    "lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gpJBpm"
                 ]
             }
         },
@@ -56,7 +56,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "lotus_16PSJQYjnqavSN7kQKQCQ29cRFrot99aLLg4iHj7R"
+                    "lotus_16PSJQYjnqavSN7kQKQCQ29cRFrot99aLLg2FPcPP"
                 ]
             }
         }

--- a/test/util/data/txcreatedata1.json
+++ b/test/util/data/txcreatedata1.json
@@ -25,7 +25,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF"
+                    "lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gpJBpm"
                 ]
             }
         },

--- a/test/util/data/txcreatedata2.json
+++ b/test/util/data/txcreatedata2.json
@@ -25,7 +25,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF"
+                    "lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gpJBpm"
                 ]
             }
         },

--- a/test/util/data/txcreatedata_seq0.json
+++ b/test/util/data/txcreatedata_seq0.json
@@ -25,7 +25,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF"
+                    "lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gpJBpm"
                 ]
             }
         }

--- a/test/util/data/txcreatedata_seq1.json
+++ b/test/util/data/txcreatedata_seq1.json
@@ -34,7 +34,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gw9trF"
+                    "lotus_16PSJJ5rwdsfaDb1FJZHyr8jodDyGZqBXD3gpJBpm"
                 ]
             }
         }

--- a/test/util/data/txcreatemultisig1.json
+++ b/test/util/data/txcreatemultisig1.json
@@ -16,9 +16,9 @@
                 "reqSigs": 2,
                 "type": "multisig",
                 "addresses": [
-                    "lotus_16PSJN5kBhektivFSZFAupfjHMxpbtWptZNbLuyFM",
-                    "lotus_16PSJMzatzDc8DpNfUyFtaY1bapfUtGCJvoLbX2FP",
-                    "lotus_16PSJJEbZRoYf1RPfQTRTrKyFyqLTVAPDJd7vcE54"
+                    "lotus_16PSJN5kBhektivFSZFAupfjHMxpbtWptZNeKw6ob",
+                    "lotus_16PSJMzatzDc8DpNfUyFtaY1bapfUtGCJvoH6Xt3x",
+                    "lotus_16PSJJEbZRoYf1RPfQTRTrKyFyqLTVAPDJd5yJ6kT"
                 ]
             }
         }

--- a/test/util/data/txcreatemultisig2.json
+++ b/test/util/data/txcreatemultisig2.json
@@ -16,7 +16,7 @@
                 "reqSigs": 1,
                 "type": "scripthash",
                 "addresses": [
-                    "lotus_1PrQMnaABKEQ4JYgJkfSdfoLfAhbjquZNBjJ6Z"
+                    "lotus_1PrQMnaABKEQ4JYgJkfSdfoLfAhbjquZSY4EB5"
                 ]
             }
         }

--- a/test/util/data/txcreatescript2.json
+++ b/test/util/data/txcreatescript2.json
@@ -16,7 +16,7 @@
                 "reqSigs": 1,
                 "type": "scripthash",
                 "addresses": [
-                    "lotus_1PrQxBkWiRorG9kcMKvFq3hoRdN8XLUy6HX3dA"
+                    "lotus_1PrQxBkWiRorG9kcMKvFq3hoRdN8XLUy4YzAHe"
                 ]
             }
         }

--- a/test/util/data/txcreatesignlotusv1-all.json
+++ b/test/util/data/txcreatesignlotusv1-all.json
@@ -25,7 +25,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "lotus_16PSJHKLkxiakqViQDC1rKbuWhdJW3xE9X3p8XuJ2"
+                    "lotus_16PSJHKLkxiakqViQDC1rKbuWhdJW3xE9X3mqZk19"
                 ]
             }
         }

--- a/test/util/data/txcreatesignlotusv2-all-anyonecanpay.json
+++ b/test/util/data/txcreatesignlotusv2-all-anyonecanpay.json
@@ -25,7 +25,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "lotus_16PSJHKLkxiakqViQDC1rKbuWhdJW3xE9X3p8XuJ2"
+                    "lotus_16PSJHKLkxiakqViQDC1rKbuWhdJW3xE9X3mqZk19"
                 ]
             }
         }

--- a/test/util/data/txcreatesignlotusv2-all.json
+++ b/test/util/data/txcreatesignlotusv2-all.json
@@ -25,7 +25,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "lotus_16PSJHKLkxiakqViQDC1rKbuWhdJW3xE9X3p8XuJ2"
+                    "lotus_16PSJHKLkxiakqViQDC1rKbuWhdJW3xE9X3mqZk19"
                 ]
             }
         }

--- a/test/util/data/txcreatesignlotusv2-none-anyonecanpay.json
+++ b/test/util/data/txcreatesignlotusv2-none-anyonecanpay.json
@@ -25,7 +25,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "lotus_16PSJHKLkxiakqViQDC1rKbuWhdJW3xE9X3p8XuJ2"
+                    "lotus_16PSJHKLkxiakqViQDC1rKbuWhdJW3xE9X3mqZk19"
                 ]
             }
         }

--- a/test/util/data/txcreatesignlotusv2-none.json
+++ b/test/util/data/txcreatesignlotusv2-none.json
@@ -25,7 +25,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "lotus_16PSJHKLkxiakqViQDC1rKbuWhdJW3xE9X3p8XuJ2"
+                    "lotus_16PSJHKLkxiakqViQDC1rKbuWhdJW3xE9X3mqZk19"
                 ]
             }
         }

--- a/test/util/data/txcreatesignlotusv2-single-anyonecanpay.json
+++ b/test/util/data/txcreatesignlotusv2-single-anyonecanpay.json
@@ -25,7 +25,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "lotus_16PSJHKLkxiakqViQDC1rKbuWhdJW3xE9X3p8XuJ2"
+                    "lotus_16PSJHKLkxiakqViQDC1rKbuWhdJW3xE9X3mqZk19"
                 ]
             }
         }

--- a/test/util/data/txcreatesignlotusv2-single.json
+++ b/test/util/data/txcreatesignlotusv2-single.json
@@ -25,7 +25,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "lotus_16PSJHKLkxiakqViQDC1rKbuWhdJW3xE9X3p8XuJ2"
+                    "lotus_16PSJHKLkxiakqViQDC1rKbuWhdJW3xE9X3mqZk19"
                 ]
             }
         }

--- a/test/util/data/txcreatesignv1.json
+++ b/test/util/data/txcreatesignv1.json
@@ -25,7 +25,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ze3Ark"
+                    "lotus_16PSJKp7nZ4j6S8GEW16tsRFBqKFhm1G4d8Ztnecn"
                 ]
             }
         }


### PR DESCRIPTION
Due to using CHashWriter, we were including VarInt sizes for the
two vectors which were included. This was a mistake and not within
the specification. This commit adds some extra checks, changes the
hash generation function, and introduces a second check to enable
legacy addresses to pass decoding for the time being.