### PR TITLE
Bump version to 1.0.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_USER_MAKE_RULES_OVERRIDE
 )
 
 project(lotus
-	VERSION 1.0.1
+	VERSION 1.0.2
 	DESCRIPTION "Lotus is a full node implementation of the Lotus protocol."
 	HOMEPAGE_URL "https://www.givelotus.org"
 )

--- a/contrib/aur/lotus-qt/PKGBUILD
+++ b/contrib/aur/lotus-qt/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Josh Ellithorpe <quest@mac.com>
 
 pkgname=lotus-qt
-pkgver=1.0.1
+pkgver=1.0.2
 pkgrel=0
 pkgdesc="Lotus with lotusd, lotus-cli, lotus-tx, lotus-seeder and lotus-qt"
 arch=('i686' 'x86_64')

--- a/contrib/aur/lotus/PKGBUILD
+++ b/contrib/aur/lotus/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Josh Ellithorpe <quest@mac.com>
 
 pkgname=lotusd
-pkgver=1.0.1
+pkgver=1.0.2
 pkgrel=0
 pkgdesc="Lotus with lotusd, lotus-tx, lotus-seeder and lotus-cli"
 arch=('i686' 'x86_64')


### PR DESCRIPTION
* Fixes an issue with check byte generation in XAddresses, but leases
  backwards compatible support for existing addresses in the wild. This
  will be removed in version 2.0.0.
* Merges in latest changes from Bitcoin ABC v0.26.7