### PR TITLE
Make XAddress parser C+11 compliant

### DIFF
--- a/src/addresses/xaddress.cpp
+++ b/src/addresses/xaddress.cpp
@@ -16,6 +16,7 @@
 
 #include <assert.h>
 #include <string>
+#include<algorithm>
 
 namespace XAddress {
 /**
@@ -95,8 +96,9 @@ DecodeError Decode(const std::string &address, Content &parsedOutput) {
         return UNDERSIZED_PAYLOAD;
     }
     const AddressType addressByte = AddressType(vch[0]);
-    parsedOutput = Content(token, networkByte, addressByte,
-                           std::vector(vch.begin() + 1, vch.end() - 4));
+    std::vector<uint8_t> payload(vch.size() - 5);
+    std::copy(vch.begin() + 1, vch.end() - 4, payload.begin());
+    parsedOutput = Content(token, networkByte, addressByte, payload);
     const uint256 check = HashAddressContents(parsedOutput);
     if (!memcmp(&check, &vch[vch.size() - 4], 4)) {
         return DECODE_OK;


### PR DESCRIPTION
The constructor used in part of the implementation for XAddresses is
using a `std::vector` constructor that is not supported until C++20. This
commit instead uses `std::copy` to perform the same operation.