### PR TITLE
Update Apple SDK URL

### DIFF
--- a/contrib/teamcity/download-apple-sdk.sh
+++ b/contrib/teamcity/download-apple-sdk.sh
@@ -19,12 +19,12 @@ DEST_DIR="$1"
 : "${TOPLEVEL:=$(git rev-parse --show-toplevel)}"
 
 OSX_SDK="Xcode-11.3.1-11C505-extracted-SDK-with-libcxx-headers.tar.gz"
-OSX_SDK_SHA256="a1b8af4c4d82d519dd5aff2135fe56184fa758c30e310b5fb4bfc8d9d3b45d8a"
+OSX_SDK_SHA256="436df6dfc7073365d12f8ef6c1fdb060777c720602cc67c2dcf9a59d94290e38"
 
 pushd "${DEST_DIR}" > /dev/null
 if ! echo "${OSX_SDK_SHA256}  ${OSX_SDK}" | sha256sum --quiet -c > /dev/null 2>&1; then
   rm -f "${OSX_SDK}"
-  wget -q https://storage.googleapis.com/27cd7b2a42a430926cc621acdc3bda72a8ed2b0efc080e3/"${OSX_SDK}"
+  wget -q https://bitcoincore.org/depends-sources/sdks/"${OSX_SDK}"
   echo "${OSX_SDK_SHA256}  ${OSX_SDK}" | sha256sum --quiet -c
 fi
 popd > /dev/null


### PR DESCRIPTION
The OSX SDK storage bucket on google cloud is no longer available,
however bitcoincore.org graciously has a version available. This commit
simply changes the path to a new host to fix OSX builds.