### PR TITLE
Refactor minerfund, remove random selection

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -91,11 +91,9 @@ public:
 
         // The miner fund is enabled by default on mainnet.
         consensus.enableMinerFund = ENABLE_MINER_FUND;
-        consensus.payoutAddressSets = RewardAddresses::MainNet::AddressSets;
-        assert(consensus.payoutAddressSets.size() == 13);
-        for (const auto &addressSet : consensus.payoutAddressSets) {
-            assert(addressSet.size() > 0);
-        }
+        consensus.coinbasePayoutAddresses =
+            RewardAddresses::MainNet::AddressSets;
+        assert(consensus.coinbasePayoutAddresses.genesis.size() == 13);
         // Mainnet rewards based on difficulty.
         consensus.enableDifficultyBasedSubsidy = true;
 
@@ -218,11 +216,9 @@ public:
 
         // The miner fund is enabled by default on testnet.
         consensus.enableMinerFund = ENABLE_MINER_FUND;
-        consensus.payoutAddressSets = RewardAddresses::TestNet::AddressSets;
-        assert(consensus.payoutAddressSets.size() == 13);
-        for (const auto &addressSet : consensus.payoutAddressSets) {
-            assert(addressSet.size() > 0);
-        }
+        consensus.coinbasePayoutAddresses =
+            RewardAddresses::TestNet::AddressSets;
+        assert(consensus.coinbasePayoutAddresses.genesis.size() == 13);
 
         // Testnet rewards based on difficulty.
         consensus.enableDifficultyBasedSubsidy = true;
@@ -323,11 +319,9 @@ public:
 
         // The miner fund is disabled by default on regnet.
         consensus.enableMinerFund = false;
-        consensus.payoutAddressSets = RewardAddresses::RegTest::AddressSets;
-        assert(consensus.payoutAddressSets.size() == 13);
-        for (const auto &addressSet : consensus.payoutAddressSets) {
-            assert(addressSet.size() > 0);
-        }
+        consensus.coinbasePayoutAddresses =
+            RewardAddresses::RegTest::AddressSets;
+        assert(consensus.coinbasePayoutAddresses.genesis.size() == 13);
         // Regtest rewards a constant amount independent of difficulty.
         consensus.enableDifficultyBasedSubsidy = false;
 

--- a/src/consensus/addresses_mainnet.h
+++ b/src/consensus/addresses_mainnet.h
@@ -1,35 +1,38 @@
 #include <string>
 #include <vector>
 
+#include <consensus/params.h>
+
 namespace RewardAddresses {
 namespace MainNet {
-    std::vector<std::vector<std::string>> AddressSets = {
-        // Foundation
-        {"pzmv0yp3kuwcd2cdv9lpu8nsdmzwud9s0upp4rxwc9"},
-        // Bitcoin ABC
-        {"qzu2u8z8ala43ae0009gr8l8lsjjl8599cdwdr9mxq"},
-        // Tobias
-        {"qz6shp4gj0vqe83wuu43n9sjxa9hknqumq0xdtwprp"},
-        // Saipan Institute
-        {"qrd8dgcmvasdewg2535uzkt9mfhgqztwg504dhsfxc"},
-        // Stamp
-        {"qqfjt5kchfhgclvelandy9fsj97vwdpf6g7sfclqsh"},
-        // Nghia
-        {"qp4pwxy34w2yxqst6f64aauudev7l3vjv5xg6dhc7x"},
-        // Remark
-        {"qqv73kxsak4ka3plqjm9d0lh9tmc6cllv5m9np8ndy"},
-        // Bitcoin Not Bombs
-        {"qrryjt2wgnwdqpg7vz52m440q2e09ydj4gupmhu3g6"},
-        // Distro Bot
-        {"qz66atlvnu5hyygvf340j5y283q7r5788vkcu6qff3"},
-        // Distro Bot
-        {"qp7z3253hyl6lzhwpfjjpg9g8apdh39ytvlwfx57mm"},
-        // Evangelism
-        {"qzccavyvf9uwwdyqwsa3txqxr5708rss4qqg8p6an4"},
-        // Distro Bot
-        {"qp7s3y735fut4vn70tvjakyt6lww4lvr55ljvaxpyn"},
-        // Distro Bot
-        {"qp9cd8u62hzhqq7lz79aeqq3ssgfmyz03vc5c4g0ct"},
-    };
+    Consensus::CoinbaseAddresses AddressSets = {
+        .genesis = {
+            // Foundation
+            "pzmv0yp3kuwcd2cdv9lpu8nsdmzwud9s0upp4rxwc9",
+            // Bitcoin ABC
+            "qzu2u8z8ala43ae0009gr8l8lsjjl8599cdwdr9mxq",
+            // Tobias
+            "qz6shp4gj0vqe83wuu43n9sjxa9hknqumq0xdtwprp",
+            // Saipan Institute
+            "qrd8dgcmvasdewg2535uzkt9mfhgqztwg504dhsfxc",
+            // Stamp
+            "qqfjt5kchfhgclvelandy9fsj97vwdpf6g7sfclqsh",
+            // Nghia
+            "qp4pwxy34w2yxqst6f64aauudev7l3vjv5xg6dhc7x",
+            // Remark
+            "qqv73kxsak4ka3plqjm9d0lh9tmc6cllv5m9np8ndy",
+            // Bitcoin Not Bombs
+            "qrryjt2wgnwdqpg7vz52m440q2e09ydj4gupmhu3g6",
+            // Distro Bot
+            "qz66atlvnu5hyygvf340j5y283q7r5788vkcu6qff3",
+            // Distro Bot
+            "qp7z3253hyl6lzhwpfjjpg9g8apdh39ytvlwfx57mm",
+            // Evangelism
+            "qzccavyvf9uwwdyqwsa3txqxr5708rss4qqg8p6an4",
+            // Distro Bot
+            "qp7s3y735fut4vn70tvjakyt6lww4lvr55ljvaxpyn",
+            // Distro Bot
+            "qp9cd8u62hzhqq7lz79aeqq3ssgfmyz03vc5c4g0ct",
+        }};
 } // namespace MainNet
 } // namespace RewardAddresses

--- a/src/consensus/addresses_regtest.h
+++ b/src/consensus/addresses_regtest.h
@@ -1,35 +1,38 @@
 #include <string>
 #include <vector>
 
+#include <consensus/params.h>
+
 namespace RewardAddresses {
 namespace RegTest {
-    std::vector<std::vector<std::string>> AddressSets = {
-        // Foundation
-        {"pzmv0yp3kuwcd2cdv9lpu8nsdmzwud9s0upp4rxwc9"},
-        // Bitcoin ABC
-        {"ppppwzhcy6kyyhkjsw0s7vvyzxz73vnwzynkaqjssk"},
-        // Be.Cash
-        {"qpwm9atcqdmr2dutnpp5h0t0hmy0y6k595qg0z5egm"},
-        // Saipan Institute
-        {"qrd8dgcmvasdewg2535uzkt9mfhgqztwg504dhsfxc"},
-        // Stamp
-        {"qqfjt5kchfhgclvelandy9fsj97vwdpf6g7sfclqsh"},
-        // Nghia
-        {"qp4pwxy34w2yxqst6f64aauudev7l3vjv5xg6dhc7x"},
-        // Remark
-        {"qqv73kxsak4ka3plqjm9d0lh9tmc6cllv5m9np8ndy"},
-        // Bitcoin Not Bombs
-        {"qrryjt2wgnwdqpg7vz52m440q2e09ydj4gupmhu3g6"},
-        // Distro Bot
-        {"qz66atlvnu5hyygvf340j5y283q7r5788vkcu6qff3"},
-        // Distro Bot
-        {"qp7z3253hyl6lzhwpfjjpg9g8apdh39ytvlwfx57mm"},
-        // Evangelism
-        {"qzccavyvf9uwwdyqwsa3txqxr5708rss4qqg8p6an4"},
-        // Distro Bot
-        {"qp7s3y735fut4vn70tvjakyt6lww4lvr55ljvaxpyn"},
-        // Koush
-        {"qrgqdz7ww5v8yqgu9ns4av5m4t4w7jxgyyxc05z9gu"},
-    };
+    Consensus::CoinbaseAddresses AddressSets = {
+        .genesis = {
+            // Foundation
+            "pzmv0yp3kuwcd2cdv9lpu8nsdmzwud9s0upp4rxwc9",
+            // Bitcoin ABC
+            "qzu2u8z8ala43ae0009gr8l8lsjjl8599cdwdr9mxq",
+            // Tobias
+            "qz6shp4gj0vqe83wuu43n9sjxa9hknqumq0xdtwprp",
+            // Saipan Institute
+            "qrd8dgcmvasdewg2535uzkt9mfhgqztwg504dhsfxc",
+            // Stamp
+            "qqfjt5kchfhgclvelandy9fsj97vwdpf6g7sfclqsh",
+            // Nghia
+            "qp4pwxy34w2yxqst6f64aauudev7l3vjv5xg6dhc7x",
+            // Remark
+            "qqv73kxsak4ka3plqjm9d0lh9tmc6cllv5m9np8ndy",
+            // Bitcoin Not Bombs
+            "qrryjt2wgnwdqpg7vz52m440q2e09ydj4gupmhu3g6",
+            // Distro Bot
+            "qz66atlvnu5hyygvf340j5y283q7r5788vkcu6qff3",
+            // Distro Bot
+            "qp7z3253hyl6lzhwpfjjpg9g8apdh39ytvlwfx57mm",
+            // Evangelism
+            "qzccavyvf9uwwdyqwsa3txqxr5708rss4qqg8p6an4",
+            // Distro Bot
+            "qp7s3y735fut4vn70tvjakyt6lww4lvr55ljvaxpyn",
+            // Distro Bot
+            "qp9cd8u62hzhqq7lz79aeqq3ssgfmyz03vc5c4g0ct",
+        }};
 } // namespace RegTest
 } // namespace RewardAddresses

--- a/src/consensus/addresses_testnet.h
+++ b/src/consensus/addresses_testnet.h
@@ -1,35 +1,38 @@
 #include <string>
 #include <vector>
 
+#include <consensus/params.h>
+
 namespace RewardAddresses {
 namespace TestNet {
-    std::vector<std::vector<std::string>> AddressSets = {
-        // Foundation
-        {"pzmv0yp3kuwcd2cdv9lpu8nsdmzwud9s0upp4rxwc9"},
-        // Bitcoin ABC
-        {"ppppwzhcy6kyyhkjsw0s7vvyzxz73vnwzynkaqjssk"},
-        // Be.Cash
-        {"qpwm9atcqdmr2dutnpp5h0t0hmy0y6k595qg0z5egm"},
-        // Saipan Institute
-        {"qrd8dgcmvasdewg2535uzkt9mfhgqztwg504dhsfxc"},
-        // Stamp
-        {"qqfjt5kchfhgclvelandy9fsj97vwdpf6g7sfclqsh"},
-        // Nghia
-        {"qp4pwxy34w2yxqst6f64aauudev7l3vjv5xg6dhc7x"},
-        // Remark
-        {"qqv73kxsak4ka3plqjm9d0lh9tmc6cllv5m9np8ndy"},
-        // Bitcoin Not Bombs
-        {"qrryjt2wgnwdqpg7vz52m440q2e09ydj4gupmhu3g6"},
-        // Distro Bot
-        {"qz66atlvnu5hyygvf340j5y283q7r5788vkcu6qff3"},
-        // Distro Bot
-        {"qp7z3253hyl6lzhwpfjjpg9g8apdh39ytvlwfx57mm"},
-        // Evangelism
-        {"qzccavyvf9uwwdyqwsa3txqxr5708rss4qqg8p6an4"},
-        // Distro Bot
-        {"qp7s3y735fut4vn70tvjakyt6lww4lvr55ljvaxpyn"},
-        // Koush
-        {"qrgqdz7ww5v8yqgu9ns4av5m4t4w7jxgyyxc05z9gu"},
-    };
+    Consensus::CoinbaseAddresses AddressSets = {
+        .genesis = {
+            // Foundation
+            "pzmv0yp3kuwcd2cdv9lpu8nsdmzwud9s0upp4rxwc9",
+            // Bitcoin ABC
+            "qzu2u8z8ala43ae0009gr8l8lsjjl8599cdwdr9mxq",
+            // Tobias
+            "qz6shp4gj0vqe83wuu43n9sjxa9hknqumq0xdtwprp",
+            // Saipan Institute
+            "qrd8dgcmvasdewg2535uzkt9mfhgqztwg504dhsfxc",
+            // Stamp
+            "qqfjt5kchfhgclvelandy9fsj97vwdpf6g7sfclqsh",
+            // Nghia
+            "qp4pwxy34w2yxqst6f64aauudev7l3vjv5xg6dhc7x",
+            // Remark
+            "qqv73kxsak4ka3plqjm9d0lh9tmc6cllv5m9np8ndy",
+            // Bitcoin Not Bombs
+            "qrryjt2wgnwdqpg7vz52m440q2e09ydj4gupmhu3g6",
+            // Distro Bot
+            "qz66atlvnu5hyygvf340j5y283q7r5788vkcu6qff3",
+            // Distro Bot
+            "qp7z3253hyl6lzhwpfjjpg9g8apdh39ytvlwfx57mm",
+            // Evangelism
+            "qzccavyvf9uwwdyqwsa3txqxr5708rss4qqg8p6an4",
+            // Distro Bot
+            "qp7s3y735fut4vn70tvjakyt6lww4lvr55ljvaxpyn",
+            // Distro Bot
+            "qp9cd8u62hzhqq7lz79aeqq3ssgfmyz03vc5c4g0ct",
+        }};
 } // namespace TestNet
 } // namespace RewardAddresses

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -14,6 +14,10 @@
 
 namespace Consensus {
 
+struct CoinbaseAddresses {
+    std::vector<std::string> genesis;
+};
+
 /**
  * Parameters that influence chain consensus.
  */
@@ -32,7 +36,7 @@ struct Params {
 
     /** Enable or disable the miner fund by default */
     bool enableMinerFund;
-    std::vector<std::vector<std::string>> payoutAddressSets;
+    CoinbaseAddresses coinbasePayoutAddresses;
 
     bool enableDifficultyBasedSubsidy;
 

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -183,7 +183,7 @@ std::string EncodeDestination(const CTxDestination &dest,
 
 CTxDestination DecodeDestination(const std::string &addr,
                                  const CChainParams &params) {
-    CTxDestination dst = DecodeCashAddr(addr, params);
+    CTxDestination dst;
     if (XAddress::Parse(params, addr, dst)) {
         return dst;
     }

--- a/src/minerfund.h
+++ b/src/minerfund.h
@@ -17,10 +17,6 @@ namespace Consensus {
 struct Params;
 }
 
-const CTxOut BuildRandomOutput(const std::vector<std::string> &addressList,
-                               uint64_t slot, Amount shareAmount,
-                               uint256 epochBlockHash);
-
 std::vector<CTxOut> GetMinerFundRequiredOutputs(const Consensus::Params &params,
                                                 const bool enableMinerFund,
                                                 const CBlockIndex *pindexPrev,

--- a/src/test/minerfund_tests.cpp
+++ b/src/test/minerfund_tests.cpp
@@ -38,126 +38,58 @@
 
 BOOST_FIXTURE_TEST_SUITE(minerfund_tests, TestChain100Setup)
 
-static void TestOutputsInSet(
-    const std::vector<CTxOut> &outputs,
-    const std::vector<CTxOut> &coinbaseOutputs,
-    std::vector<std::vector<CTxDestination>> &allowedDestinationSets) {
-    std::vector<CTxDestination> emptySet;
-    // Check random funding address outputs
-    auto outputsIt = outputs.begin();
-    auto coinbaseOutsIt = coinbaseOutputs.begin() + 2;
-    for (size_t idx = 0; idx < 12; idx++) {
-        const auto &allowedSet = allowedDestinationSets[idx];
-        BOOST_CHECK_MESSAGE(outputsIt->scriptPubKey ==
-                                coinbaseOutsIt->scriptPubKey,
-                            "Mismatched scriptPubKey on coinbase");
-        BOOST_CHECK_MESSAGE(outputsIt->nValue == coinbaseOutsIt->nValue,
-                            "Mismatched coinbase value of output");
-
-        CTxDestination dest;
-        ExtractDestination(outputsIt->scriptPubKey, dest);
-
-        const auto foundTx =
-            std::find_if(allowedSet.begin(), allowedSet.end(),
-                         [dest](const auto &a) -> bool { return dest == a; });
-        BOOST_CHECK_MESSAGE(
-            foundTx != allowedSet.end(),
-            "Infrastructure coinbase payout not found in allowable set");
-
-        // Check that we're ensuring destinations match
-        const auto isInEmptySet =
-            std::find_if(emptySet.begin(), emptySet.end(),
-                         [dest](const auto &a) -> bool { return dest == a; });
-        BOOST_CHECK_MESSAGE(isInEmptySet == emptySet.end(),
-                            "CTxDestination operator equality failing");
-        outputsIt++;
-        coinbaseOutsIt++;
+static void
+CheckMinerfundOutputs(const std::vector<CTxOut> &outputs,
+                      const std::vector<std::string> &expectedAddresses,
+                      const Amount expectedAmount) {
+    BOOST_CHECK_EQUAL(outputs.size(), expectedAddresses.size());
+    const CChainParams mainNetParams =
+        *CreateChainParams(CBaseChainParams::MAIN);
+    for (size_t i = 0; i < outputs.size(); ++i) {
+        const CTxOut &output = outputs[i];
+        const std::string &expectedAddress = expectedAddresses[i];
+        CTxDestination dst = DecodeDestination(expectedAddress, mainNetParams);
+        if (!IsValidDestination(dst)) {
+            // Try the bitcoincash cashaddr prefix.
+            dst = DecodeCashAddrDestination(
+                DecodeCashAddrContent(expectedAddress, "bitcoincash"));
+        }
+        const CScript expectedScript = GetScriptForDestination(dst);
+        BOOST_CHECK(output.scriptPubKey == expectedScript);
+        BOOST_CHECK_EQUAL(output.nValue, expectedAmount);
     }
 }
 
-static size_t CompareOutputs(const std::vector<CTxOut> &outputsA,
-                             const std::vector<CTxOut> &outputsB) {
-    std::vector<CTxDestination> emptySet;
-    // Check random funding address outputs only
-    auto outputsAIt = outputsA.begin() + 2;
-    auto outputsBIt = outputsB.begin() + 2;
-    BOOST_CHECK_MESSAGE(outputsA.size() == outputsB.size(),
-                        "Mismatched coinbase output count");
-    size_t matches = 0;
-    for (size_t idx = 2; idx < outputsA.size(); idx++) {
-        BOOST_CHECK_MESSAGE(outputsAIt->nValue == outputsBIt->nValue,
-                            "Mismatched coinbase value of output");
-        matches += outputsAIt->scriptPubKey != outputsBIt->scriptPubKey;
-        outputsAIt++;
-        outputsBIt++;
-    }
-    return matches < outputsA.size() - 2;
-}
-
-BOOST_AUTO_TEST_CASE(test_outputs) {
+BOOST_AUTO_TEST_CASE(test_minerfund_required_outputs) {
     // Note that by default, these tests run with size accounting enabled.
     GlobalConfig config;
-    // Don't check this functionality in this test.
+    // Do check this functionality in this test.
     config.SetEnableMinerFund(true);
     const CChainParams &chainparams = config.GetChainParams();
+    const Consensus::Params &consensus = chainparams.GetConsensus();
     // We mine some blocks, thus we need some basic setup.
     BlockAssembler::Options options;
     options.blockMinFeeRate = CFeeRate(1000 * SATOSHI, 1000);
     options.enableMinerFund = config.EnableMinerFund();
-    auto testAssembler = BlockAssembler(chainparams, *m_node.mempool, options);
+    BlockAssembler testAssembler(chainparams, *m_node.mempool, options);
 
-    const auto &consensus = chainparams.GetConsensus();
     // Simple consensus transaction.
     CScript scriptPubKey = CScript() << OP_RETURN;
     std::unique_ptr<CBlockTemplate> pblocktemplate;
 
     fCheckpointsEnabled = false;
 
-    const auto mainNetParams = CreateChainParams(CBaseChainParams::MAIN);
-
-    // Normalize addresses for search purposes
-    std::vector<std::vector<CTxDestination>> payoutAddressDestinations;
-    for (const auto &addressSet : consensus.payoutAddressSets) {
-        payoutAddressDestinations.emplace_back(std::vector<CTxDestination>());
-        for (const auto &address : addressSet) {
-            auto dest = DecodeDestination(address, *mainNetParams);
-            if(!IsValidDestination(dest)) {
-            // Try the ecash cashaddr prefix.
-                dest = DecodeCashAddrDestination(DecodeCashAddrContent(address, "bitcoincash"));
-            }
-            payoutAddressDestinations.back().emplace_back(dest);
-        }
-    }
-
-    // At least two blocks should have different epochs
-    size_t differentBlocks = 0;
-    for (size_t i = 0; i < 5002; i++) {
+    for (size_t i = 0; i < 100; i++) {
         // Simple block creation
         BOOST_CHECK(pblocktemplate =
                         testAssembler.CreateNewBlock(scriptPubKey));
         CBlock *pblock = &pblocktemplate->block;
-        const auto &coinbaseOutputs = pblock->vtx[0]->vout;
-        const auto pPrev = ::ChainActive().Tip();
-        const auto pPrevPrev = pPrev->pprev;
+        const std::vector<CTxOut> &coinbaseOutputs = pblock->vtx[0]->vout;
+        const CBlockIndex *pPrev = ::ChainActive().Tip();
 
-        // Output hashes are based on previous block's epoch.
-        if (pPrev->hashEpochBlock != pPrevPrev->hashEpochBlock) {
-            differentBlocks++;
-            CBlock block;
-            ReadBlockFromDisk(block, pPrev,
-                              config.GetChainParams().GetConsensus());
-
-            const auto commonOutputs =
-                CompareOutputs(block.vtx[0]->vout, coinbaseOutputs);
-            BOOST_CHECK_MESSAGE(
-                commonOutputs < 5,
-                "Coinbase outputs matched when they should not have: "
-                    << commonOutputs);
-        }
-        const auto subsidy =
-            GetBlockSubsidy(::ChainActive().Tip()->nBits, consensus);
-        const auto outputs = GetMinerFundRequiredOutputs(
-            consensus, true, ::ChainActive().Tip(), subsidy);
+        const Amount subsidy = GetBlockSubsidy(pPrev->nBits, consensus);
+        const std::vector<CTxOut> outputs =
+            GetMinerFundRequiredOutputs(consensus, true, pPrev, subsidy);
         // outputs + 2 for OP_RETURN for block height unique hash, and
         // coinbase output
         BOOST_CHECK_MESSAGE(outputs.size() + 2 == coinbaseOutputs.size(),
@@ -166,17 +98,16 @@ BOOST_AUTO_TEST_CASE(test_outputs) {
         // OP_RETURN Commitment, Miner payout, and funding set
         BOOST_CHECK_EQUAL(coinbaseOutputs.size(), 15);
 
-        // Check random funding address outputs
-        TestOutputsInSet(outputs, coinbaseOutputs, payoutAddressDestinations);
+        // Check funding address outputs
+        CheckMinerfundOutputs(
+            outputs, consensus.coinbasePayoutAddresses.genesis, subsidy / 26);
 
         // Update block so it can be connected, and the epoch will update
         // through this test.
-        UpdateTime(pblock, chainparams, ::ChainActive().Tip());
+        UpdateTime(pblock, chainparams, pPrev);
         pblock->nNonce = 0;
         pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
-        const Consensus::Params &params =
-            config.GetChainParams().GetConsensus();
-        while (!CheckProofOfWork(pblock->GetHash(), pblock->nBits, params)) {
+        while (!CheckProofOfWork(pblock->GetHash(), pblock->nBits, consensus)) {
             ++pblock->nNonce;
         }
         std::shared_ptr<const CBlock> shared_pblock =
@@ -186,92 +117,6 @@ BOOST_AUTO_TEST_CASE(test_outputs) {
             Assert(m_node.chainman)
                 ->ProcessNewBlock(config, shared_pblock, true, nullptr));
     }
-
-    BOOST_CHECK_MESSAGE(differentBlocks > 0,
-                        "Should have passed through an epoch");
-}
-
-double TestVariance(size_t epochs, std::map<uint256, size_t> &histogram) {
-    double variance = 0;
-    double expectation = epochs / histogram.size();
-    for (const auto &match : histogram) {
-        // std::cout << match.first << " : " << match.second << std::endl;
-        variance += (match.second - expectation) * (match.second - expectation);
-    }
-    variance *= histogram.size();
-    variance /= epochs;
-    // std::cout << variance << std::endl;
-
-    return variance;
-}
-
-bool TestRandomEpochHashes(std::vector<std::string> &addressList, size_t epochs,
-                           double threshold) {
-    std::map<uint256, size_t> histogram;
-    // Different epochs produce different results.
-    for (size_t i = 0; i < epochs; i++) {
-        const auto fakeEpochHash = InsecureRand256();
-        const CTxOut output =
-            BuildRandomOutput(addressList, 1, 260 * LOTUS, fakeEpochHash);
-        const auto scriptPubKeyBytes = Hash(ToByteVector(output.scriptPubKey));
-        histogram[scriptPubKeyBytes]++;
-    }
-    return TestVariance(epochs, histogram) > threshold;
-}
-
-bool TestRandomSlots(std::vector<std::string> &addressList, size_t epochs,
-                     double threshold) {
-    std::map<uint256, size_t> histogram;
-    // Different epochs produce different results.
-    for (size_t i = 0; i < epochs; i++) {
-        const auto fakeEpochHash = InsecureRand256();
-        const CTxOut output =
-            BuildRandomOutput(addressList, 1, 260 * LOTUS, fakeEpochHash);
-        const auto scriptPubKeyBytes = Hash(ToByteVector(output.scriptPubKey));
-        histogram[scriptPubKeyBytes]++;
-    }
-    return TestVariance(epochs, histogram) > threshold;
-}
-
-BOOST_AUTO_TEST_CASE(test_randomness) {
-    std::random_device rd;
-    const auto mainNetParams = *CreateChainParams(CBaseChainParams::MAIN);
-    auto gen = [&rd]() { return uint8_t(rd()); };
-
-    // Using 52 epochs for a year to compare hits
-    // The threshold should fail once out of every 1000 tests for these
-    // parameters.
-    // Degrees of freedom tested
-    size_t df = 9;
-    // Test is independent of number of samples. Minimized for speed.
-    const size_t totalEpochsToCheck = 52;
-    const size_t trials = 1000;
-    const double criticalThreshold = 27.877;
-    const uint32_t maxFailures = 2 * trials / 1000;
-    // Generate some addresses
-    std::vector<std::string> addressList;
-    for (size_t i = 0; i < df + 1; i++) {
-        std::vector<uint8_t> fakeKeyBytes(32);
-        std::generate(begin(fakeKeyBytes), end(fakeKeyBytes), gen);
-        const CTxDestination dest = PKHash(Hash160(fakeKeyBytes));
-        addressList.emplace_back(EncodeDestination(dest, mainNetParams));
-    }
-
-    uint32_t failures = 0;
-    for (size_t i = 0; i < trials; i++) {
-        failures += TestRandomEpochHashes(addressList, totalEpochsToCheck,
-                                          criticalThreshold);
-    }
-    BOOST_CHECK_MESSAGE(failures <= maxFailures,
-                        "Uniformity test failed too many times: " << failures);
-
-    failures = 0;
-    for (size_t i = 0; i < trials; i++) {
-        failures +=
-            TestRandomSlots(addressList, totalEpochsToCheck, criticalThreshold);
-    }
-    BOOST_CHECK_MESSAGE(failures <= maxFailures,
-                        "Uniformity test failed too many times: " << failures);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Previously, the coinbase outputs for the minerfund were randomly picked from a set of addresses based on `hashEpochBlock`.

However, establishing such a set turned out to be difficult. Therefore, the address sets always contained only one entry, so that address would always be picked.

This PR removes picking the addresses at random, in order to simplify adding activation code down the line.