### PR TITLE
Add `leviticusactivationtime`, bump replay protecc

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -108,6 +108,8 @@ public:
 
         // 2021-12-21T15:59:00.000Z protocol upgrade
         consensus.exodusActivationTime = 1640102340;
+        // 2022-06-21T09:14:00.000Z protocol upgrade
+        consensus.leviticusActivationTime = 1655802840;
 
         /**
          * The message start string is designed to be unlikely to occur in
@@ -234,6 +236,8 @@ public:
 
         // 2021-12-21T15:59:00.000Z protocol upgrade
         consensus.exodusActivationTime = 1640102340;
+        // 2022-06-21T09:14:00.000Z protocol upgrade
+        consensus.leviticusActivationTime = 1655802840;
 
         // "ltdk" with MSB set
         diskMagic[0] = 0xec;
@@ -334,6 +338,8 @@ public:
 
         // 2021-12-21T15:59:00.000Z protocol upgrade
         consensus.exodusActivationTime = 1640102340;
+        // 2022-06-21T09:14:00.000Z protocol upgrade
+        consensus.leviticusActivationTime = 1655802840;
 
         // "lrdk" with MSB set
         diskMagic[0] = 0xec;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -24,8 +24,12 @@ struct CoinbaseAddresses {
 struct Params {
     BlockHash hashGenesisBlock;
     int nSubsidyHalvingInterval;
-    /** Unix time used for MTP activation of 2021-12-21T15:59:00.000Z protocol upgrade */
+    /** Unix time used for MTP activation of 2021-12-21T15:59:00.000Z protocol
+     * upgrade */
     int exodusActivationTime;
+    /** Unix time used for MTP activation of 2022-06-21T09:14:00.000Z protocol
+     * upgrade */
+    int leviticusActivationTime;
 
     /**
      * Don't warn about unknown BIP 9 activations below this height.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -419,7 +419,7 @@ void SetupServerArgs(NodeContext &node) {
         "-min", "-resetguisettings", "-rootcertificates=<file>", "-splash",
         "-uiplatform",
         // TODO remove after the December 2021 upgrade
-        "-exodusactivationtime"};
+        "-exodusactivationtime", "-leviticusactivationtime"};
 
     // Set all of the args and their help
     // When adding new options to the categories, please keep and ensure

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -277,7 +277,7 @@ bool CheckSequenceLocks(const CTxMemPool &pool, const CTransaction &tx,
 static bool IsReplayProtectionEnabled(const Consensus::Params &params,
                                       int64_t nMedianTimePast) {
     return nMedianTimePast >= gArgs.GetArg("-replayprotectionactivationtime",
-                                           params.exodusActivationTime);
+                                           params.leviticusActivationTime);
 }
 
 static bool IsReplayProtectionEnabled(const Consensus::Params &params,


### PR DESCRIPTION
Nodes automatically fork off from the network if not upgraded at the determined timestamp.
This change bumps the "fork off" timestamp (replayprotectiontime) to 2022-06-21 09:14:00, such that the node continues to accept normally signed (non-replay protected) transactions at the Exodus network upgrade.