### PR TITLE
Fix default param in `download-apple-sdk.sh`

### DIFF
--- a/contrib/teamcity/download-apple-sdk.sh
+++ b/contrib/teamcity/download-apple-sdk.sh
@@ -4,7 +4,7 @@ export LC_ALL=C
 
 set -euxo pipefail
 
-: "${SDK_DL_REMOTE:=}"
+: "${SDK_DL_REMOTE:=https://bitcoincore.org/depends-sources/sdks/}"
 
 usage() {
   echo "Usage: download-apple-sdk.sh dest_dir"
@@ -27,7 +27,7 @@ OSX_SDK_SHA256="436df6dfc7073365d12f8ef6c1fdb060777c720602cc67c2dcf9a59d94290e38
 pushd "${DEST_DIR}" > /dev/null
 if ! echo "${OSX_SDK_SHA256}  ${OSX_SDK}" | sha256sum --quiet -c > /dev/null 2>&1; then
   rm -f "${OSX_SDK}"
-  wget -q https://bitcoincore.org/depends-sources/sdks/"${OSX_SDK}"
+  wget -q "${SDK_DL_REMOTE}/${OSX_SDK}"
   echo "${OSX_SDK_SHA256}  ${OSX_SDK}" | sha256sum --quiet -c
 fi
 popd > /dev/null


### PR DESCRIPTION
Previous, this URL was removed from being public by Bitcoin ABC due to
the original resource hosting this being taken down. However, Bitcoin
Core also hosts the SDK. This commit changes the default parameter for
where to download the SDK to use Core's repository.