### PR TITLE
Use BASEPREFIX in platform toolchain cmake files

### DIFF
--- a/cmake/platforms/Linux32.cmake
+++ b/cmake/platforms/Linux32.cmake
@@ -13,10 +13,10 @@ set(CMAKE_CXX_COMPILER_TARGET ${TOOLCHAIN_PREFIX})
 
 # Target environment on the build host system
 # Set 1st to directory with the cross compiler's C/C++ headers/libs
-set(CMAKE_FIND_ROOT_PATH "${CMAKE_CURRENT_SOURCE_DIR}/depends/${TOOLCHAIN_PREFIX}")
+set(CMAKE_FIND_ROOT_PATH "${BASEPREFIX}/${TOOLCHAIN_PREFIX}")
 
 # We also may have built dependencies for the native platform.
-set(CMAKE_PREFIX_PATH "${CMAKE_CURRENT_SOURCE_DIR}/depends/${TOOLCHAIN_PREFIX}/native")
+set(CMAKE_PREFIX_PATH "${BASEPREFIX}/${TOOLCHAIN_PREFIX}/native")
 
 # Modify default behavior of FIND_XXX() commands to:
 #  - search for headers in the target environment,

--- a/cmake/platforms/Linux64.cmake
+++ b/cmake/platforms/Linux64.cmake
@@ -13,10 +13,10 @@ set(CMAKE_CXX_COMPILER_TARGET ${TOOLCHAIN_PREFIX})
 
 # Target environment on the build host system
 # Set 1st to directory with the cross compiler's C/C++ headers/libs
-set(CMAKE_FIND_ROOT_PATH "${CMAKE_CURRENT_SOURCE_DIR}/depends/${TOOLCHAIN_PREFIX}")
+set(CMAKE_FIND_ROOT_PATH "${BASEPREFIX}/${TOOLCHAIN_PREFIX}")
 
 # We also may have built dependencies for the native platform.
-set(CMAKE_PREFIX_PATH "${CMAKE_CURRENT_SOURCE_DIR}/depends/${TOOLCHAIN_PREFIX}/native")
+set(CMAKE_PREFIX_PATH "${BASEPREFIX}/${TOOLCHAIN_PREFIX}/native")
 
 # Modify default behavior of FIND_XXX() commands to:
 #  - search for headers in the target environment,

--- a/cmake/platforms/LinuxAArch64.cmake
+++ b/cmake/platforms/LinuxAArch64.cmake
@@ -14,12 +14,12 @@ set(CMAKE_CXX_COMPILER_TARGET ${TOOLCHAIN_PREFIX})
 # Target environment on the build host system
 # Set 1st to directory with the cross compiler's C/C++ headers/libs
 set(CMAKE_FIND_ROOT_PATH
-	"${CMAKE_CURRENT_SOURCE_DIR}/depends/${TOOLCHAIN_PREFIX}"
+	"${BASEPREFIX}/${TOOLCHAIN_PREFIX}"
 	"/usr/${TOOLCHAIN_PREFIX}"
 )
 
 # We also may have built dependencies for the native platform.
-set(CMAKE_PREFIX_PATH "${CMAKE_CURRENT_SOURCE_DIR}/depends/${TOOLCHAIN_PREFIX}/native")
+set(CMAKE_PREFIX_PATH "${BASEPREFIX}/${TOOLCHAIN_PREFIX}/native")
 
 # Modify default behavior of FIND_XXX() commands to
 # search for headers/libs in the target environment and

--- a/cmake/platforms/LinuxARM.cmake
+++ b/cmake/platforms/LinuxARM.cmake
@@ -14,12 +14,12 @@ set(CMAKE_CXX_COMPILER_TARGET ${TOOLCHAIN_PREFIX})
 # Target environment on the build host system
 # Set 1st to directory with the cross compiler's C/C++ headers/libs
 set(CMAKE_FIND_ROOT_PATH
-	"${CMAKE_CURRENT_SOURCE_DIR}/depends/${TOOLCHAIN_PREFIX}"
+	"${BASEPREFIX}/${TOOLCHAIN_PREFIX}"
 	"/usr/${TOOLCHAIN_PREFIX}"
 )
 
 # We also may have built dependencies for the native platform.
-set(CMAKE_PREFIX_PATH "${CMAKE_CURRENT_SOURCE_DIR}/depends/${TOOLCHAIN_PREFIX}/native")
+set(CMAKE_PREFIX_PATH "${BASEPREFIX}/${TOOLCHAIN_PREFIX}/native")
 
 # Modify default behavior of FIND_XXX() commands to
 # search for headers/libs in the target environment and

--- a/cmake/platforms/OSX.cmake
+++ b/cmake/platforms/OSX.cmake
@@ -19,17 +19,17 @@ set(SDK_XCODE_BUILD_ID 11C505)
 set(LD64_VERSION 530)
 
 # On OSX we use various stuff from Apple's SDK.
-set(OSX_SDK_PATH "${CMAKE_CURRENT_SOURCE_DIR}/depends/SDKs/Xcode-${SDK_XCODE_VERSION}-${SDK_XCODE_BUILD_ID}-extracted-SDK-with-libcxx-headers")
+set(OSX_SDK_PATH "${BASEPREFIX}/SDKs/Xcode-${SDK_XCODE_VERSION}-${SDK_XCODE_BUILD_ID}-extracted-SDK-with-libcxx-headers")
 set(CMAKE_OSX_SYSROOT "${OSX_SDK_PATH}")
 set(CMAKE_OSX_DEPLOYMENT_TARGET ${OSX_MIN_VERSION})
 set(CMAKE_OSX_ARCHITECTURES x86_64)
 
 # target environment on the build host system
 #   set 1st to dir with the cross compiler's C/C++ headers/libs
-set(CMAKE_FIND_ROOT_PATH "${CMAKE_CURRENT_SOURCE_DIR}/depends/${TOOLCHAIN_PREFIX};${OSX_SDK_PATH}")
+set(CMAKE_FIND_ROOT_PATH "${BASEPREFIX}/${TOOLCHAIN_PREFIX};${OSX_SDK_PATH}")
 
 # We also may have built dependencies for the native plateform.
-set(CMAKE_PREFIX_PATH "${CMAKE_CURRENT_SOURCE_DIR}/depends/${TOOLCHAIN_PREFIX}/native")
+set(CMAKE_PREFIX_PATH "${BASEPREFIX}/${TOOLCHAIN_PREFIX}/native")
 
 # modify default behavior of FIND_XXX() commands to
 # search for headers/libs in the target environment and

--- a/cmake/platforms/Win32.cmake
+++ b/cmake/platforms/Win32.cmake
@@ -14,10 +14,10 @@ set(CMAKE_CXX_COMPILER_TARGET ${TOOLCHAIN_PREFIX})
 
 # target environment on the build host system
 #   set 1st to dir with the cross compiler's C/C++ headers/libs
-set(CMAKE_FIND_ROOT_PATH "${CMAKE_CURRENT_SOURCE_DIR}/depends/${TOOLCHAIN_PREFIX};/usr/${TOOLCHAIN_PREFIX}")
+set(CMAKE_FIND_ROOT_PATH "${BASEPREFIX}/${TOOLCHAIN_PREFIX};/usr/${TOOLCHAIN_PREFIX}")
 
 # We also may have built dependencies for the native plateform.
-set(CMAKE_PREFIX_PATH "${CMAKE_CURRENT_SOURCE_DIR}/depends/${TOOLCHAIN_PREFIX}/native")
+set(CMAKE_PREFIX_PATH "${BASEPREFIX}/${TOOLCHAIN_PREFIX}/native")
 
 # modify default behavior of FIND_XXX() commands to
 # search for headers/libs in the target environment and

--- a/cmake/platforms/Win64.cmake
+++ b/cmake/platforms/Win64.cmake
@@ -14,10 +14,10 @@ set(CMAKE_CXX_COMPILER_TARGET ${TOOLCHAIN_PREFIX})
 
 # target environment on the build host system
 #   set 1st to dir with the cross compiler's C/C++ headers/libs
-set(CMAKE_FIND_ROOT_PATH "${CMAKE_CURRENT_SOURCE_DIR}/depends/${TOOLCHAIN_PREFIX};/usr/${TOOLCHAIN_PREFIX}")
+set(CMAKE_FIND_ROOT_PATH "${BASEPREFIX}/${TOOLCHAIN_PREFIX};/usr/${TOOLCHAIN_PREFIX}")
 
 # We also may have built dependencies for the native plateform.
-set(CMAKE_PREFIX_PATH "${CMAKE_CURRENT_SOURCE_DIR}/depends/${TOOLCHAIN_PREFIX}/native")
+set(CMAKE_PREFIX_PATH "${BASEPREFIX}/${TOOLCHAIN_PREFIX}/native")
 
 # modify default behavior of FIND_XXX() commands to
 # search for headers/libs in the target environment and

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -108,7 +108,10 @@ script: |
   BASEPREFIX=`pwd`/depends
   # Build dependencies for each host
   for i in ${HOSTS[@]}; do
-    make ${MAKEOPTS} -C ${BASEPREFIX} HOST="${i}"
+    make ${MAKEOPTS} -C ${BASEPREFIX} \
+      HOST="${i}" \
+      CMAKE_TOOLCHAIN_FILE="${SOURCEDIR}/cmake/platforms/${CMAKE_TOOLCHAIN_FILE[${i}]}" \
+      BASEPREFIX="${BASEPREFIX}"
   done
 
   # Faketime for binaries
@@ -122,7 +125,8 @@ script: |
   # Any toolchain file will work for building the source package, just pick the
   # first one
   cmake -GNinja .. \
-    -DCMAKE_TOOLCHAIN_FILE=${SOURCEDIR}/cmake/platforms/${CMAKE_TOOLCHAIN_FILE[${HOSTS[0]}]}
+    -DCMAKE_TOOLCHAIN_FILE=${SOURCEDIR}/cmake/platforms/${CMAKE_TOOLCHAIN_FILE[${HOSTS[0]}]} \
+    -DBASEPREFIX=${BASEPREFIX}
 
   ninja package_source
   SOURCEDIST=`echo lotus-*.tar.gz`
@@ -148,6 +152,7 @@ script: |
 
     cmake -GNinja .. \
       -DCMAKE_TOOLCHAIN_FILE=${SOURCEDIR}/cmake/platforms/${CMAKE_TOOLCHAIN_FILE[${i}]} \
+      -DBASEPREFIX=${BASEPREFIX} \
       -DCLIENT_VERSION_IS_RELEASE=ON \
       -DENABLE_CLANG_TIDY=OFF \
       -DENABLE_REDUCE_EXPORTS=ON \

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -104,7 +104,10 @@ script: |
 
   # Build dependencies for each host
   for i in ${HOSTS[@]}; do
-    make ${MAKEOPTS} -C ${BASEPREFIX} HOST="${i}"
+    make ${MAKEOPTS} -C ${BASEPREFIX} \
+      HOST="${i}" \
+      CMAKE_TOOLCHAIN_FILE="${SOURCEDIR}/cmake/platforms/${CMAKE_TOOLCHAIN_FILE[${i}]}" \
+      BASEPREFIX="${BASEPREFIX}"
   done
 
   # Faketime for binaries
@@ -118,7 +121,8 @@ script: |
   # Any toolchain file will work for building the source package, just pick the
   # first one
   cmake -GNinja .. \
-    -DCMAKE_TOOLCHAIN_FILE=${SOURCEDIR}/cmake/platforms/${CMAKE_TOOLCHAIN_FILE[${HOSTS[0]}]}
+    -DCMAKE_TOOLCHAIN_FILE=${SOURCEDIR}/cmake/platforms/${CMAKE_TOOLCHAIN_FILE[${HOSTS[0]}]} \
+    -DBASEPREFIX=${BASEPREFIX}
 
   ninja package_source
   SOURCEDIST=`echo lotus-*.tar.gz`
@@ -145,6 +149,7 @@ script: |
 
     cmake -GNinja .. \
       -DCMAKE_TOOLCHAIN_FILE=${SOURCEDIR}/cmake/platforms/${CMAKE_TOOLCHAIN_FILE[${i}]} \
+      -DBASEPREFIX=${BASEPREFIX} \
       -DCLIENT_VERSION_IS_RELEASE=ON \
       -DENABLE_CLANG_TIDY=OFF \
       -DENABLE_REDUCE_EXPORTS=ON \

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -118,7 +118,10 @@ script: |
   BASEPREFIX=`pwd`/depends
   # Build dependencies for each host
   for i in ${HOSTS[@]}; do
-    make ${MAKEOPTS} -C ${BASEPREFIX} HOST="${i}"
+    make ${MAKEOPTS} -C ${BASEPREFIX} \
+      HOST="${i}" \
+      CMAKE_TOOLCHAIN_FILE="${SOURCEDIR}/cmake/platforms/${CMAKE_TOOLCHAIN_FILE[${i}]}" \
+      BASEPREFIX="${BASEPREFIX}"
   done
 
   # Faketime for binaries
@@ -133,7 +136,8 @@ script: |
   # Any toolchain file will work for building the source package, just pick the
   # first one
   cmake -GNinja .. \
-    -DCMAKE_TOOLCHAIN_FILE=${SOURCEDIR}/cmake/platforms/${CMAKE_TOOLCHAIN_FILE[${HOSTS[0]}]}
+    -DCMAKE_TOOLCHAIN_FILE=${SOURCEDIR}/cmake/platforms/${CMAKE_TOOLCHAIN_FILE[${HOSTS[0]}]} \
+    -DBASEPREFIX=${BASEPREFIX}
 
   ninja package_source
   SOURCEDIST=`echo lotus-*.tar.gz`
@@ -166,6 +170,7 @@ script: |
 
     cmake -GNinja .. \
       -DCMAKE_TOOLCHAIN_FILE=${SOURCEDIR}/cmake/platforms/${CMAKE_TOOLCHAIN_FILE[${i}]} \
+      -DBASEPREFIX=${BASEPREFIX} \
       -DCLIENT_VERSION_IS_RELEASE=ON \
       -DENABLE_CLANG_TIDY=OFF \
       -DENABLE_REDUCE_EXPORTS=ON \


### PR DESCRIPTION
Currently, the platform toolchain cmake files (Linux32.cmake, OSX.cmake, etc.) all use CMAKE_CURRENT_SOURCE_DIR to build the toolchain path.
This breaks however once the toolchain files are used from a different source directory, e.g. when building dependencies.
By threading the BASEPREFIX through the build system, the toolchain files can also be used by dependencies.