### PR TITLE
Add Flatbuffers dependency

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -39,6 +39,7 @@ NO_WALLET ?=
 NO_ZMQ ?=
 NO_UPNP ?=
 NO_JEMALLOC ?=
+NO_FLATBUFFERS ?=
 FALLBACK_DOWNLOAD_PATH ?= https://download.bitcoinabc.org/depends-sources
 
 BUILD = $(shell ./config.guess)
@@ -140,6 +141,8 @@ protobuf_packages_$(NO_PROTOBUF) = $(protobuf_packages)
 
 jemalloc_packages_$(NO_JEMALLOC) = $(jemalloc_packages)
 
+Flatbuffers_packages_$(NO_FLATBUFFERS) = $(Flatbuffers_packages)
+
 packages += $($(host_arch)_$(host_os)_packages) $($(host_os)_packages) $(qt_packages_) $(wallet_packages_) $(upnp_packages_)
 native_packages += $($(host_arch)_$(host_os)_native_packages) $($(host_os)_native_packages)
 
@@ -154,6 +157,11 @@ endif
 
 ifneq ($(jemalloc_packages_),)
 packages += $(jemalloc_packages)
+endif
+
+ifneq ($(Flatbuffers_packages_),)
+packages += $(Flatbuffers_packages)
+native_packages += $(Flatbuffers_native_packages)
 endif
 
 all_packages = $(packages) $(native_packages)

--- a/depends/packages/Flatbuffers.mk
+++ b/depends/packages/Flatbuffers.mk
@@ -1,0 +1,33 @@
+package=Flatbuffers
+$(package)_version=$(native_$(package)_version)
+$(package)_download_path=$(native_$(package)_download_path)
+$(package)_file_name=$(native_$(package)_file_name)
+$(package)_sha256_hash=$(native_$(package)_sha256_hash)
+$(package)_dependencies=native_$(package)
+
+define $(package)_set_vars
+  $(package)_cxxflags=-std=c++11
+endef
+
+define $(package)_config_cmds
+  cmake -GNinja \
+    -DCMAKE_INSTALL_PREFIX=$($(package)_staging_dir)/$(host_prefix) \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DFLATBUFFERS_BUILD_TESTS=off \
+    -DFLATBUFFERS_BUILD_FLATC=off \
+    -DFLATBUFFERS_BUILD_FLATHASH=off \
+    -DCMAKE_TOOLCHAIN_FILE=$(CMAKE_TOOLCHAIN_FILE) \
+    -DBASEPREFIX=$(BASEPREFIX)
+endef
+
+define $(package)_build_cmds
+  ninja
+endef
+
+define $(package)_stage_cmds
+  ninja install
+endef
+
+define $(package)_postprocess_cmds
+  rm -rf bin lib
+endef

--- a/depends/packages/native_Flatbuffers.mk
+++ b/depends/packages/native_Flatbuffers.mk
@@ -1,0 +1,29 @@
+package=native_Flatbuffers
+$(package)_version=2.0.0
+$(package)_download_path=https://github.com/google/flatbuffers/archive/refs/tags/
+$(package)_file_name=v$($(package)_version).tar.gz
+$(package)_sha256_hash=9ddb9031798f4f8754d00fca2f1a68ecf9d0f83dfac7239af1311e4fd9a565c4
+
+define $(package)_set_vars
+  $(package)_cxxflags=-std=c++11
+endef
+
+define $(package)_config_cmds
+  cmake -GNinja \
+    -DCMAKE_INSTALL_PREFIX=$(build_prefix) \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DFLATBUFFERS_BUILD_TESTS=off \
+    -DFLATBUFFERS_BUILD_FLATHASH=off
+endef
+
+define $(package)_build_cmds
+  ninja
+endef
+
+define $(package)_stage_cmds
+  DESTDIR=$($(package)_staging_dir) ninja install
+endef
+
+define $(package)_postprocess_cmds
+  rm -rf include 
+endef

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -25,3 +25,6 @@ darwin_native_packages += native_cctools native_cdrkit native_libdmg-hfsplus
 endif
 
 jemalloc_packages = jemalloc
+
+Flatbuffers_packages=Flatbuffers
+Flatbuffers_native_packages=native_Flatbuffers


### PR DESCRIPTION
This is used by the nng interface down the line.

The native_Flatbuffers.mk is for building flatc, which has to be built with the host architecture. Flatbuffers.mk builds for the target architecture, which is then used by lotusd.