### PR TITLE
Add nng dependency

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -39,6 +39,7 @@ NO_WALLET ?=
 NO_ZMQ ?=
 NO_UPNP ?=
 NO_JEMALLOC ?=
+NO_NNG ?=
 NO_FLATBUFFERS ?=
 FALLBACK_DOWNLOAD_PATH ?= https://download.bitcoinabc.org/depends-sources
 
@@ -141,6 +142,7 @@ protobuf_packages_$(NO_PROTOBUF) = $(protobuf_packages)
 
 jemalloc_packages_$(NO_JEMALLOC) = $(jemalloc_packages)
 
+nng_packages_$(NO_NNG) = $(nng_packages)
 Flatbuffers_packages_$(NO_FLATBUFFERS) = $(Flatbuffers_packages)
 
 packages += $($(host_arch)_$(host_os)_packages) $($(host_os)_packages) $(qt_packages_) $(wallet_packages_) $(upnp_packages_)
@@ -157,6 +159,10 @@ endif
 
 ifneq ($(jemalloc_packages_),)
 packages += $(jemalloc_packages)
+endif
+
+ifneq ($(nng_packages_),)
+packages += $(nng_packages)
 endif
 
 ifneq ($(Flatbuffers_packages_),)

--- a/depends/packages/nng.mk
+++ b/depends/packages/nng.mk
@@ -1,0 +1,28 @@
+package=nng
+$(package)_version=1.5.2
+$(package)_download_path=https://github.com/nanomsg/nng/archive/refs/tags/
+$(package)_file_name=v$($(package)_version).tar.gz
+$(package)_sha256_hash=f8b25ab86738864b1f2e3128e8badab581510fa8085ff5ca9bb980d317334c46
+$(package)_patches=remove_deps.patch
+
+define $(package)_preprocess_cmds
+  patch -p1 < $($(package)_patch_dir)/remove_deps.patch
+endef
+
+define $(package)_config_cmds
+  cmake -GNinja \
+    -DCMAKE_INSTALL_PREFIX=$($(package)_staging_dir)/$(host_prefix) \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CROSSCOMPILING=on \
+    -DNNG_ENABLE_NNGCAT=off \
+    -DCMAKE_TOOLCHAIN_FILE=$(CMAKE_TOOLCHAIN_FILE) \
+    -DBASEPREFIX=$(BASEPREFIX)
+endef
+
+define $(package)_build_cmds
+  ninja
+endef
+
+define $(package)_stage_cmds
+  ninja install
+endef

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -26,5 +26,7 @@ endif
 
 jemalloc_packages = jemalloc
 
+nng_packages=nng
+
 Flatbuffers_packages=Flatbuffers
 Flatbuffers_native_packages=native_Flatbuffers

--- a/depends/patches/nng/remove_deps.patch
+++ b/depends/patches/nng/remove_deps.patch
@@ -1,0 +1,31 @@
+From 91c8e9db8ab57ad056824c57f24c270bdecfcff1 Mon Sep 17 00:00:00 2001
+From: Tobias Ruck <ruck.tobias@gmail.com>
+Date: Fri, 31 Dec 2021 16:58:41 -0600
+Subject: [PATCH] Remove dependencies that will fail the bitcoind build
+
+---
+ src/platform/posix/CMakeLists.txt | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/src/platform/posix/CMakeLists.txt b/src/platform/posix/CMakeLists.txt
+index 02a8cb53..880b2320 100644
+--- a/src/platform/posix/CMakeLists.txt
++++ b/src/platform/posix/CMakeLists.txt
+@@ -26,15 +26,12 @@ if (NNG_PLATFORM_POSIX)
+
+     nng_check_func(lockf NNG_HAVE_LOCKF)
+     nng_check_func(flock NNG_HAVE_FLOCK)
+-    nng_check_func(getrandom NNG_HAVE_GETRANDOM)
+     nng_check_func(arc4random_buf NNG_HAVE_ARC4RANDOM)
+
+-    nng_check_lib(rt clock_gettime NNG_HAVE_CLOCK_GETTIME)
+     nng_check_lib(pthread sem_wait NNG_HAVE_SEMAPHORE_PTHREAD)
+     nng_check_lib(pthread pthread_atfork NNG_HAVE_PTHREAD_ATFORK_PTHREAD)
+     nng_check_lib(pthread pthread_set_name_np NNG_HAVE_PTHREAD_SET_NAME_NP)
+     nng_check_lib(pthread pthread_setname_np NNG_HAVE_PTHREAD_SETNAME_NP)
+-    nng_check_lib(nsl gethostbyname NNG_HAVE_LIBNSL)
+     nng_check_lib(socket socket NNG_HAVE_LIBSOCKET)
+
+     # GCC needs libatomic on some architectures (e.g. ARM) because the
+-- 
+2.30.1 (Apple Git-130)


### PR DESCRIPTION
This is used by the nng interface down the line.

`nngcat` causes problems when cross-compiling, and isn't used anyway, so we disable it.