### PR TITLE
Add `spent_coins` to TransactionAddedToMempool

### DIFF
--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -72,7 +72,9 @@ namespace {
             std::shared_ptr<Chain::Notifications> notifications)
             : m_notifications(std::move(notifications)) {}
         virtual ~NotificationsProxy() = default;
-        void TransactionAddedToMempool(const CTransactionRef &tx) override {
+        void TransactionAddedToMempool(
+            const CTransactionRef &tx,
+            const std::vector<Coin> &spent_coins) override {
             m_notifications->transactionAddedToMempool(tx);
         }
         void

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -739,7 +739,15 @@ bool MemPoolAccept::AcceptSingleTransaction(const CTransactionRef &ptx,
         return false;
     }
 
-    GetMainSignals().TransactionAddedToMempool(ptx);
+    std::vector<Coin> spent_coins;
+    spent_coins.reserve(ptx->vin.size());
+    for (const CTxIn &input : ptx->vin) {
+        Coin coin;
+        m_view.GetCoin(input.prevout, coin);
+        spent_coins.push_back(coin);
+    }
+    GetMainSignals().TransactionAddedToMempool(ptx, spent_coins);
+
     return true;
 }
 

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -203,10 +203,11 @@ void CMainSignals::UpdatedBlockTip(const CBlockIndex *pindexNew,
         fInitialDownload);
 }
 
-void CMainSignals::TransactionAddedToMempool(const CTransactionRef &tx) {
-    auto event = [tx, this] {
+void CMainSignals::TransactionAddedToMempool(
+    const CTransactionRef &tx, const std::vector<Coin> &spent_coins) {
+    auto event = [tx, spent_coins, this] {
         m_internals->Iterate([&](CValidationInterface &callbacks) {
-            callbacks.TransactionAddedToMempool(tx);
+            callbacks.TransactionAddedToMempool(tx, spent_coins);
         });
     };
     ENQUEUE_AND_LOG_EVENT(event, "%s: txid=%s", __func__,

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_VALIDATIONINTERFACE_H
 #define BITCOIN_VALIDATIONINTERFACE_H
 
+#include <coins.h>
 #include <primitives/transaction.h> // CTransaction(Ref)
 #include <sync.h>
 
@@ -105,7 +106,9 @@ protected:
      *
      * Called on a background thread.
      */
-    virtual void TransactionAddedToMempool(const CTransactionRef &tx) {}
+    virtual void
+    TransactionAddedToMempool(const CTransactionRef &tx,
+                              const std::vector<Coin> &spent_coins) {}
     /**
      * Notifies listeners of a transaction leaving mempool.
      *
@@ -219,7 +222,8 @@ public:
 
     void UpdatedBlockTip(const CBlockIndex *, const CBlockIndex *,
                          bool fInitialDownload);
-    void TransactionAddedToMempool(const CTransactionRef &);
+    void TransactionAddedToMempool(const CTransactionRef &,
+                                   const std::vector<Coin> &);
     void TransactionRemovedFromMempool(const CTransactionRef &,
                                        MemPoolRemovalReason);
     void BlockConnected(const std::shared_ptr<const CBlock> &,

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -149,7 +149,7 @@ void CZMQNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew,
 }
 
 void CZMQNotificationInterface::TransactionAddedToMempool(
-    const CTransactionRef &ptx) {
+    const CTransactionRef &ptx, const std::vector<Coin> &spent_coins) {
     // Used by BlockConnected and BlockDisconnected as well, because they're all
     // the same external callback.
     const CTransaction &tx = *ptx;
@@ -171,7 +171,7 @@ void CZMQNotificationInterface::BlockConnected(
     const CBlockIndex *pindexConnected) {
     for (const CTransactionRef &ptx : pblock->vtx) {
         // Do a normal notify for each transaction added in the block
-        TransactionAddedToMempool(ptx);
+        TransactionAddedToMempool(ptx, {} /* unused */);
     }
 }
 
@@ -181,7 +181,7 @@ void CZMQNotificationInterface::BlockDisconnected(
     for (const CTransactionRef &ptx : pblock->vtx) {
         // Do a normal notify for each transaction removed in block
         // disconnection
-        TransactionAddedToMempool(ptx);
+        TransactionAddedToMempool(ptx, {} /* unused */);
     }
 }
 

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -25,7 +25,9 @@ protected:
     void Shutdown();
 
     // CValidationInterface
-    void TransactionAddedToMempool(const CTransactionRef &tx) override;
+    void
+    TransactionAddedToMempool(const CTransactionRef &tx,
+                              const std::vector<Coin> &spent_coins) override;
     void BlockConnected(const std::shared_ptr<const CBlock> &pblock,
                         const CBlockIndex *pindexConnected) override;
     void BlockDisconnected(const std::shared_ptr<const CBlock> &pblock,


### PR DESCRIPTION
Access to `spent_coins` is required for the NNG interface. This adds it to `CValidationInterface`.