### PR TITLE
Add `IsLeviticusEnabled`

### DIFF
--- a/src/consensus/activation.cpp
+++ b/src/consensus/activation.cpp
@@ -17,3 +17,13 @@ bool IsExodusEnabled(const Consensus::Params &params,
     return pindexPrev->GetMedianTimePast() >=
            gArgs.GetArg("-exodusactivationtime", params.exodusActivationTime);
 }
+
+bool IsLeviticusEnabled(const Consensus::Params &params,
+                        const CBlockIndex *pindexPrev) {
+    if (pindexPrev == nullptr) {
+        return false;
+    }
+
+    return pindexPrev->GetMedianTimePast() >=
+           gArgs.GetArg("-leviticusactivationtime", params.leviticusActivationTime);
+}

--- a/src/consensus/activation.h
+++ b/src/consensus/activation.h
@@ -15,4 +15,8 @@ struct Params;
 bool IsExodusEnabled(const Consensus::Params &params,
                      const CBlockIndex *pindexPrev);
 
+/** Check if June 21st, 2022 protocol upgrade has activated. */
+bool IsLeviticusEnabled(const Consensus::Params &params,
+                        const CBlockIndex *pindexPrev);
+
 #endif // BITCOIN_CONSENSUS_ACTIVATION_H

--- a/src/test/activation_tests.cpp
+++ b/src/test/activation_tests.cpp
@@ -47,4 +47,28 @@ BOOST_AUTO_TEST_CASE(isexodusenabled) {
     BOOST_CHECK(IsExodusEnabled(params, &blocks.back()));
 }
 
+BOOST_AUTO_TEST_CASE(isleviticusenabled) {
+    const Consensus::Params &params = Params().GetConsensus();
+    const auto activation =
+        gArgs.GetArg("-leviticusactivationtime", params.leviticusActivationTime);
+    SetMockTime(activation - 1000000);
+
+    BOOST_CHECK(!IsLeviticusEnabled(params, nullptr));
+
+    std::array<CBlockIndex, 12> blocks;
+    for (size_t i = 1; i < blocks.size(); ++i) {
+        blocks[i].pprev = &blocks[i - 1];
+    }
+    BOOST_CHECK(!IsLeviticusEnabled(params, &blocks.back()));
+
+    SetMTP(blocks, activation - 1);
+    BOOST_CHECK(!IsLeviticusEnabled(params, &blocks.back()));
+
+    SetMTP(blocks, activation);
+    BOOST_CHECK(IsLeviticusEnabled(params, &blocks.back()));
+
+    SetMTP(blocks, activation + 1);
+    BOOST_CHECK(IsLeviticusEnabled(params, &blocks.back()));
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Returns whether MTP has moved past `leviticusactivationtime`.