### PR TITLE
Bump version to 3.1.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_USER_MAKE_RULES_OVERRIDE
 )
 
 project(lotus
-	VERSION 2.1.3
+	VERSION 3.1.3
 	DESCRIPTION "Lotus is a full node implementation of the Lotus protocol."
 	HOMEPAGE_URL "https://www.givelotus.org"
 )

--- a/contrib/aur/lotus/PKGBUILD
+++ b/contrib/aur/lotus/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Josh Ellithorpe <quest@mac.com>
 
 pkgname=lotusd
-pkgver=2.1.3
+pkgver=3.1.3
 pkgrel=0
 pkgdesc="Lotus with lotusd, lotus-tx, lotus-seeder and lotus-cli"
 arch=('i686' 'x86_64')


### PR DESCRIPTION
Supports the Leviticus network upgrade.