### PR TITLE
Hotfix replay protection activation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_USER_MAKE_RULES_OVERRIDE
 )
 
 project(lotus
-	VERSION 3.1.3
+	VERSION 3.1.4
 	DESCRIPTION "Lotus is a full node implementation of the Lotus protocol."
 	HOMEPAGE_URL "https://www.givelotus.org"
 )

--- a/contrib/aur/lotus/PKGBUILD
+++ b/contrib/aur/lotus/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Josh Ellithorpe <quest@mac.com>
 
 pkgname=lotusd
-pkgver=3.1.3
+pkgver=3.1.4
 pkgrel=0
 pkgdesc="Lotus with lotusd, lotus-tx, lotus-seeder and lotus-cli"
 arch=('i686' 'x86_64')

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -110,6 +110,8 @@ public:
         consensus.exodusActivationTime = 1640102340;
         // 2022-06-21T09:14:00.000Z protocol upgrade
         consensus.leviticusActivationTime = 1655802840;
+        // 2022-12-21T21:48:00.000Z protocol upgrade
+        consensus.numbersActivationTime = 1671659280;
 
         /**
          * The message start string is designed to be unlikely to occur in
@@ -238,6 +240,8 @@ public:
         consensus.exodusActivationTime = 1640102340;
         // 2022-06-21T09:14:00.000Z protocol upgrade
         consensus.leviticusActivationTime = 1655802840;
+        // 2022-12-21T21:48:00.000Z protocol upgrade
+        consensus.numbersActivationTime = 1671659280;
 
         // "ltdk" with MSB set
         diskMagic[0] = 0xec;
@@ -340,6 +344,8 @@ public:
         consensus.exodusActivationTime = 1640102340;
         // 2022-06-21T09:14:00.000Z protocol upgrade
         consensus.leviticusActivationTime = 1655802840;
+        // 2022-12-21T21:48:00.000Z protocol upgrade
+        consensus.numbersActivationTime = 1671659280;
 
         // "lrdk" with MSB set
         diskMagic[0] = 0xec;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -32,6 +32,9 @@ struct Params {
     /** Unix time used for MTP activation of 2022-06-21T09:14:00.000Z protocol
      * upgrade */
     int leviticusActivationTime;
+    /** Unix time used for MTP activation of 2022-12-21T21:48:00.000Z protocol
+     * upgrade */
+    int numbersActivationTime;
 
     /**
      * Don't warn about unknown BIP 9 activations below this height.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -277,7 +277,7 @@ bool CheckSequenceLocks(const CTxMemPool &pool, const CTransaction &tx,
 static bool IsReplayProtectionEnabled(const Consensus::Params &params,
                                       int64_t nMedianTimePast) {
     return nMedianTimePast >= gArgs.GetArg("-replayprotectionactivationtime",
-                                           params.leviticusActivationTime);
+                                           params.numbersActivationTime);
 }
 
 static bool IsReplayProtectionEnabled(const Consensus::Params &params,


### PR DESCRIPTION
By mistake the replay protection has not been bumped, this means txs with signatures are all rejected.