### PR TITLE
Fix testnet minerfund addresses

### DIFF
--- a/src/consensus/addresses_testnet.h
+++ b/src/consensus/addresses_testnet.h
@@ -10,9 +10,9 @@ namespace TestNet {
             // Foundation
             "pzmv0yp3kuwcd2cdv9lpu8nsdmzwud9s0upp4rxwc9",
             // Bitcoin ABC
-            "qzu2u8z8ala43ae0009gr8l8lsjjl8599cdwdr9mxq",
-            // Tobias
-            "qz6shp4gj0vqe83wuu43n9sjxa9hknqumq0xdtwprp",
+            "ppppwzhcy6kyyhkjsw0s7vvyzxz73vnwzynkaqjssk",
+            // Be.Cash
+            "qpwm9atcqdmr2dutnpp5h0t0hmy0y6k595qg0z5egm",
             // Saipan Institute
             "qrd8dgcmvasdewg2535uzkt9mfhgqztwg504dhsfxc",
             // Stamp
@@ -31,8 +31,8 @@ namespace TestNet {
             "qzccavyvf9uwwdyqwsa3txqxr5708rss4qqg8p6an4",
             // Distro Bot
             "qp7s3y735fut4vn70tvjakyt6lww4lvr55ljvaxpyn",
-            // Distro Bot
-            "qp9cd8u62hzhqq7lz79aeqq3ssgfmyz03vc5c4g0ct",
+            // Koush
+            "qrgqdz7ww5v8yqgu9ns4av5m4t4w7jxgyyxc05z9gu",
         },
         .exodus = {
             // Aleph 0


### PR DESCRIPTION
When removing the random selection of addresses, there was a copy
and paste error which changed the miner fund addresses for the genesis
testnet fork. This commit changes those addresses back so that the
testnet blocks validate from a brand new resync.