### PR TITLE
Set min testnet difficulty to 1

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -205,7 +205,7 @@ public:
         consensus.nSubsidyHalvingInterval = 210000;
 
         consensus.powLimit = uint256S(
-            "0000000010000000000000000000000000000000000000000000000000000000");
+            "00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         // two weeks
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60;
         consensus.nPowTargetSpacing = 2 * 60;


### PR DESCRIPTION
Currently, the PoW limit for the testnet is needlessly high with a minimum difficulty of ~16. This change reduces the difficulty to 1.