### PR TITLE
Fix off-by-one bug in `GetFirstUndoOffset`

### DIFF
--- a/src/nng_interface/nng_interface.cpp
+++ b/src/nng_interface/nng_interface.cpp
@@ -399,7 +399,7 @@ size_t GetFirstBlockTxOffset(const CBlock &block, const CBlockIndex *pindex) {
 }
 
 size_t GetFirstUndoOffset(const CBlock &block, const CBlockIndex *pindex) {
-    return pindex->nUndoPos + GetSizeOfCompactSize(block.vtx.size());
+    return pindex->nUndoPos + GetSizeOfCompactSize(block.vtx.size() - 1);
 }
 
 flatbuffers::Offset<NngInterface::Block>


### PR DESCRIPTION
This would calculate the wrong undo pos for blocks that have exactly 253 transactions.