### PR TITLE
Fix `GetBlockSubsidy` for difficulty < ~16

### DIFF
--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -85,6 +85,8 @@ static void TestBlockSubsidyLogarithmic(const Consensus::Params &params) {
         {0x1000ffff, int64_t(26'260'005'725) * SATOSHI},
         {0x0500ffff, int64_t(49'140'005'725) * SATOSHI},
         {0x0300ffff, int64_t(53'300'005'725) * SATOSHI},
+        {0x1c100001, 1 * SUBSIDY}, // for testnet
+        {0x1d00ffff, 1 * SUBSIDY}, // for testnet
     };
     for (const auto &pair : test_cases) {
         const Amount subsidy = GetBlockSubsidy(pair.first, params);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -862,7 +862,8 @@ static bool WriteBlockToDisk(const CBlock &block, FlatFilePos &pos,
 Amount GetBlockSubsidy(uint32_t nBits,
                        const Consensus::Params &consensusParams) {
     static constexpr int64_t SUBSIDY_INT = SUBSIDY / SATOSHI;
-    if (!consensusParams.enableDifficultyBasedSubsidy) {
+    // Always cap on regtest, and sometimes we need to cap on testnet.
+    if (!consensusParams.enableDifficultyBasedSubsidy || nBits > 0x1c100000) {
         return SUBSIDY;
     }
     // We define:
@@ -889,8 +890,6 @@ Amount GetBlockSubsidy(uint32_t nBits,
     static constexpr int64_t LOG_MAX_TARGET = 220;
     const int64_t exp = nBits >> 24;
     const uint32_t mantissa = (nBits & 0x007fffff);
-    // CheckProofOfWork ensures this
-    assert(nBits <= 0x1c100000);
     // First check in ContextualCheckBlockHeader ensures this (since nBits have
     // to match exactly, enforcing canonical encoding)
     assert(mantissa >= 0x8000);


### PR DESCRIPTION
Currently, this function asserts nBits <= 0x1c100000, but the on the testnet, this can now fall below that, so we simply cap the subsidy in this case.