### PR TITLE
Bump version number to 3.3.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_USER_MAKE_RULES_OVERRIDE
 )
 
 project(lotus
-	VERSION 3.2.3
+	VERSION 3.3.3
 	DESCRIPTION "Lotus is a full node implementation of the Lotus protocol."
 	HOMEPAGE_URL "https://www.givelotus.org"
 )

--- a/contrib/aur/lotus/PKGBUILD
+++ b/contrib/aur/lotus/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Josh Ellithorpe <quest@mac.com>
 
 pkgname=lotusd
-pkgver=3.2.3
+pkgver=3.3.3
 pkgrel=0
 pkgdesc="Lotus with lotusd, lotus-tx, lotus-seeder and lotus-cli"
 arch=('i686' 'x86_64')


### PR DESCRIPTION
* Fixes address bug which caused the testnet to become corrupted
  (Did not effect mainnet)
* Drop testnet difficulty to 1
* Use same address sets for testnet, mainnet, and regtest to avoid
  future confusion.
* Fix off by one error in nng interface for chronik and other services