### PR TITLE
Fix build with Boost 1.77.0

### DIFF
--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -236,8 +236,13 @@ void ofstream::close() {
 }
 #else // __GLIBCXX__
 
+#if BOOST_VERSION >= 107700
+static_assert(
+    sizeof(*BOOST_FILESYSTEM_C_STR(fs::path())) == sizeof(wchar_t),
+#else
 static_assert(
     sizeof(*fs::path().BOOST_FILESYSTEM_C_STR) == sizeof(wchar_t),
+#endif // BOOST_VERSION >= 107700
     "Warning: This build is using boost::filesystem ofstream and ifstream "
     "implementations which will fail to open paths containing multibyte "
     "characters. You should delete this static_assert to ignore this warning, "

--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -18,7 +18,11 @@ BOOST_AUTO_TEST_CASE(getwalletenv_file) {
     std::string test_name = "test_name.dat";
     const fs::path datadir = GetDataDir();
     fs::path file_path = datadir / test_name;
+#if BOOST_VERSION >= 107700
+    std::ofstream f(BOOST_FILESYSTEM_C_STR(file_path));
+#else
     std::ofstream f(file_path.BOOST_FILESYSTEM_C_STR);
+#endif // BOOST_VERSION >= 107700
     f.close();
 
     std::string filename;

--- a/src/wallet/test/init_test_fixture.cpp
+++ b/src/wallet/test/init_test_fixture.cpp
@@ -34,7 +34,11 @@ InitWalletDirTestingSetup::InitWalletDirTestingSetup(
     fs::create_directories(m_walletdir_path_cases["default"]);
     fs::create_directories(m_walletdir_path_cases["custom"]);
     fs::create_directories(m_walletdir_path_cases["relative"]);
+#if BOOST_VERSION >= 107700
+    std::ofstream f(BOOST_FILESYSTEM_C_STR(m_walletdir_path_cases["file"]));
+#else
     std::ofstream f(m_walletdir_path_cases["file"].BOOST_FILESYSTEM_C_STR);
+#endif // BOOST_VERSION >= 107700
     f.close();
 }
 


### PR DESCRIPTION
This is a backport of https://reviews.bitcoinabc.org/D10769

It is needed to run `ninja check` with boost 1.77.

The error I'm getting without this is:
```
/home/p/dev/lotusd/src/wallet/test/init_test_fixture.cpp: In constructor ‘InitWalletDirTestingSetup::InitWalletDirTestingSetup(const string&)’:
/home/p/dev/lotusd/src/wallet/test/init_test_fixture.cpp:37:52: error: ‘std::map<std::__cxx11::basic_string<char>, boost::filesystem::path>::mapped_type’ {aka ‘class boost::filesystem::path’} has no member named ‘BOOST_FILESYSTEM_C_STR’
   37 |     std::ofstream f(m_walletdir_path_cases["file"].BOOST_FILESYSTEM_C_STR);
      |                                                    ^~~~~~~~~~~~~~~~~~~~~~

```