### PR TITLE
[docs] Add dependencies and build instructions for NNG and flatbuffers

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -44,6 +44,9 @@ Optional dependencies:
  libqrencode | QR codes in GUI  | Optional for generating QR codes (only needed when GUI enabled)
  univalue    | Utility          | JSON parsing and encoding (bundled version will be used unless --with-system-univalue passed to configure)
  libzmq3     | ZMQ notification | Optional, allows generating ZMQ notifications (requires ZMQ version >= 4.1.5)
+ nng         | NNG interface    | See [nng.md](nng.md)
+ flatbuffers | Serialization    | Used by the NNG interface
+
 
 For the versions used, see [dependencies.md](dependencies.md)
 
@@ -120,6 +123,27 @@ ZMQ dependencies (provides ZMQ API, can be disabled by passing `-DBUILD_BITCOIN_
 jemalloc dependencies (provides the jemalloc library, can be disabled by passing `-DUSE_JEMALLOC=OFF` on the cmake command line):
 
     sudo apt-get install libjemalloc-dev
+
+nng dependencies (can be disabled by passing `-DBUILD_BITCOIN_NNG=OFF` on the cmake command line):
+
+    sudo apt-get install libnng-dev
+
+FlatBuffers (if 2.0.0 is available in the package repository):
+
+    sudo apt-get install libflatbuffers-dev
+
+If the repository does not have the correct version, install it from source:
+
+    wget https://github.com/google/flatbuffers/archive/refs/tags/v2.0.0.tar.gz
+    echo "9ddb9031798f4f8754d00fca2f1a68ecf9d0f83dfac7239af1311e4fd9a565c4 v2.0.0.tar.gz" | sha256sum -c
+    tar -zxf v2.0.0.tar.gz
+    (
+      cd flatbuffers-2.0.0
+      mkdir build
+      cd build
+      cmake -GNinja -DCMAKE_BUILD_TYPE=Release ..
+      sudo ninja install
+    )
 
 Dependencies for the GUI: Ubuntu & Debian
 -----------------------------------------

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -10,6 +10,7 @@ These are the dependencies currently used by Bitcoin ABC. You can find instructi
 | Clang |  | [5](https://releases.llvm.org/download.html) (C++17 support) |  |  |  |
 | CMake |  | [3.16](https://cmake.org/download/) |  |  |  |
 | Expat | [2.2.7](https://libexpat.github.io/) |  | No | Yes |  |
+| FlatBuffers |  | [2.0.0](https://github.com/google/flatbuffers/releases) |  |  |  |
 | fontconfig | [2.12.6](https://www.freedesktop.org/software/fontconfig/release/) |  | No | Yes |  |
 | FreeType | [2.7.1](http://download.savannah.gnu.org/releases/freetype) |  | No |  |  |
 | GCC |  | [7](https://gcc.gnu.org/) (C++17 support) |  |  |  |
@@ -20,6 +21,7 @@ These are the dependencies currently used by Bitcoin ABC. You can find instructi
 | librsvg | |  |  |  |  |
 | MiniUPnPc | [2.0.20180203](https://miniupnp.tuxfamily.org/files) | 1.9 | No |  |  |
 | Ninja |  | [1.5.1](https://github.com/ninja-build/ninja/releases) |  |  |  |
+| nng |  | [1.5.2](https://github.com/nanomsg/nng/releases) |  |  |  |
 | OpenSSL | [1.0.1k](https://www.openssl.org/source) |  | Yes |  |  |
 | PCRE |  |  |  |  | Yes |
 | protobuf | [2.6.1](https://github.com/google/protobuf/releases) |  | No |  |  |
@@ -43,6 +45,7 @@ factors that affect the dependency list.
 * Qt is not needed with `-DBUILD_BITCOIN_QT=OFF`.
 * qrencode is not needed with `-DENABLE_QRCODE=OFF`.
 * ZeroMQ is not needed with the `-DBUILD_BITCOIN_ZMQ=OFF`.
+* nng and FlatBuffers are not needed with the `-DBUILD_BITCOIN_NNG=OFF`.
 
 #### Other
 * librsvg is only needed if you need to run `ninja osx-dmg` on


### PR DESCRIPTION
Add in missing documentation about flatbuffers and nng dependencies to
the build documentation.