### PR TITLE
Add numbersactivationtime and, bump replay protecc time

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -109,6 +109,8 @@ public:
         consensus.leviticusActivationTime = 1655802840;
         // 2022-12-21T21:48:00.000Z protocol upgrade
         consensus.numbersActivationTime = 1671659280;
+        // 2023-06-21T14:58:00.000Z protocol upgrade
+        consensus.deuteronomyActivationTime = 1687359480;
 
         /**
          * The message start string is designed to be unlikely to occur in
@@ -244,6 +246,10 @@ public:
         // 2022-12-12T21:48:00.000Z protocol upgrade
         consensus.numbersActivationTime =
             mainnetConsensus.numbersActivationTime - testnetActivationOffset;
+        // 2023-06-21T14:58:00.000Z protocol upgrade
+        consensus.deuteronomyActivationTime =
+            mainnetConsensus.deuteronomyActivationTime -
+            testnetActivationOffset;
 
         // "ltdk" with MSB set
         diskMagic[0] = 0xec;
@@ -351,6 +357,9 @@ public:
         // 2022-12-12T21:48:00.000Z protocol upgrade
         consensus.numbersActivationTime =
             mainnetConsensus.numbersActivationTime;
+        // 2023-06-21T14:58:00.000Z protocol upgrade
+        consensus.deuteronomyActivationTime =
+            mainnetConsensus.deuteronomyActivationTime;
 
         // "lrdk" with MSB set
         diskMagic[0] = 0xec;

--- a/src/consensus/activation.cpp
+++ b/src/consensus/activation.cpp
@@ -27,3 +27,18 @@ bool IsLeviticusEnabled(const Consensus::Params &params,
     return pindexPrev->GetMedianTimePast() >=
            gArgs.GetArg("-leviticusactivationtime", params.leviticusActivationTime);
 }
+
+bool IsNumbersEnabled(const Consensus::Params &params,
+                      const int64_t nMedianTimePast) {
+    return nMedianTimePast >=
+           gArgs.GetArg("-numbersactivationtime", params.numbersActivationTime);
+}
+
+bool IsNumbersEnabled(const Consensus::Params &params,
+                      const CBlockIndex *pindexPrev) {
+    if (pindexPrev == nullptr) {
+        return false;
+    }
+
+    return IsNumbersEnabled(params, pindexPrev->GetMedianTimePast());
+}

--- a/src/consensus/activation.h
+++ b/src/consensus/activation.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_CONSENSUS_ACTIVATION_H
 #define BITCOIN_CONSENSUS_ACTIVATION_H
 
+#include <cstdint>
+
 class CBlockIndex;
 
 namespace Consensus {
@@ -18,5 +20,11 @@ bool IsExodusEnabled(const Consensus::Params &params,
 /** Check if June 21st, 2022 protocol upgrade has activated. */
 bool IsLeviticusEnabled(const Consensus::Params &params,
                         const CBlockIndex *pindexPrev);
+
+/** Check if December 21st, 2022 protocol upgrade has activated. */
+bool IsNumbersEnabled(const Consensus::Params &params,
+                      const int64_t nMedianTimePast);
+bool IsNumbersEnabled(const Consensus::Params &params,
+                      const CBlockIndex *pindexPrev);
 
 #endif // BITCOIN_CONSENSUS_ACTIVATION_H

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -35,6 +35,9 @@ struct Params {
     /** Unix time used for MTP activation of 2022-12-12T21:48:00.000Z protocol
      * upgrade */
     int numbersActivationTime;
+    /** Unix time used for MTP activation of 2023-06-21T14:58:00.000Z protocol
+     * upgrade */
+    int deuteronomyActivationTime;
 
     /**
      * Don't warn about unknown BIP 9 activations below this height.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -424,7 +424,7 @@ void SetupServerArgs(NodeContext &node) {
         "-min", "-resetguisettings", "-rootcertificates=<file>", "-splash",
         "-uiplatform",
         // TODO remove after the December 2021 upgrade
-        "-exodusactivationtime", "-leviticusactivationtime"};
+        "-exodusactivationtime", "-leviticusactivationtime", "-numbersactivationtime"};
 
     // Set all of the args and their help
     // When adding new options to the categories, please keep and ensure

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -277,7 +277,7 @@ function(add_boost_test_runners_with_upgrade_activated SUITE EXECUTABLE)
 			# Dec. 1st, 2019 at 00:00:00
 			--
 			"-testsuitename=Bitcoin ABC unit tests with next upgrade activated"
-			-leviticusactivationtime=1575158400
+			-numbersactivationtime=1575158400
 		)
 	endforeach()
 endfunction()

--- a/src/test/activation_tests.cpp
+++ b/src/test/activation_tests.cpp
@@ -49,8 +49,8 @@ BOOST_AUTO_TEST_CASE(isexodusenabled) {
 
 BOOST_AUTO_TEST_CASE(isleviticusenabled) {
     const Consensus::Params &params = Params().GetConsensus();
-    const auto activation =
-        gArgs.GetArg("-leviticusactivationtime", params.leviticusActivationTime);
+    const auto activation = gArgs.GetArg("-leviticusactivationtime",
+                                         params.leviticusActivationTime);
     SetMockTime(activation - 1000000);
 
     BOOST_CHECK(!IsLeviticusEnabled(params, nullptr));
@@ -69,6 +69,42 @@ BOOST_AUTO_TEST_CASE(isleviticusenabled) {
 
     SetMTP(blocks, activation + 1);
     BOOST_CHECK(IsLeviticusEnabled(params, &blocks.back()));
+}
+
+BOOST_AUTO_TEST_CASE(isnumbersenabled) {
+    const Consensus::Params &params = Params().GetConsensus();
+    const auto activation =
+        gArgs.GetArg("-numbersactivationtime", params.numbersActivationTime);
+    SetMockTime(activation - 1000000);
+
+    BOOST_CHECK(!IsNumbersEnabled(params, nullptr));
+
+    std::array<CBlockIndex, 12> blocks;
+    for (size_t i = 1; i < blocks.size(); ++i) {
+        blocks[i].pprev = &blocks[i - 1];
+    }
+    BOOST_CHECK(!IsNumbersEnabled(params, &blocks.back()));
+    BOOST_CHECK_EQUAL(
+        IsNumbersEnabled(params, &blocks.back()),
+        IsNumbersEnabled(params, blocks.back().GetMedianTimePast()));
+
+    SetMTP(blocks, activation - 1);
+    BOOST_CHECK(!IsNumbersEnabled(params, &blocks.back()));
+    BOOST_CHECK_EQUAL(
+        IsNumbersEnabled(params, &blocks.back()),
+        IsNumbersEnabled(params, blocks.back().GetMedianTimePast()));
+
+    SetMTP(blocks, activation);
+    BOOST_CHECK(IsNumbersEnabled(params, &blocks.back()));
+    BOOST_CHECK_EQUAL(
+        IsNumbersEnabled(params, &blocks.back()),
+        IsNumbersEnabled(params, blocks.back().GetMedianTimePast()));
+
+    SetMTP(blocks, activation + 1);
+    BOOST_CHECK(IsNumbersEnabled(params, &blocks.back()));
+    BOOST_CHECK_EQUAL(
+        IsNumbersEnabled(params, &blocks.back()),
+        IsNumbersEnabled(params, blocks.back().GetMedianTimePast()));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -277,7 +277,7 @@ bool CheckSequenceLocks(const CTxMemPool &pool, const CTransaction &tx,
 static bool IsReplayProtectionEnabled(const Consensus::Params &params,
                                       int64_t nMedianTimePast) {
     return nMedianTimePast >= gArgs.GetArg("-replayprotectionactivationtime",
-                                           params.numbersActivationTime);
+                                           params.deuteronomyActivationTime);
 }
 
 static bool IsReplayProtectionEnabled(const Consensus::Params &params,

--- a/test/functional/logos_feature_minerfund_activation.py
+++ b/test/functional/logos_feature_minerfund_activation.py
@@ -27,6 +27,7 @@ from test_framework.util import assert_equal
 
 EXODUS_ACTIVATION_TIME = 2000000000
 LEVITICUS_ACTIVATION_TIME = 2010000000
+NUMBERS_ACTIVATION_TIME = 2020000000
 
 # see consensus/addresses.h
 GENESIS_SCRIPTS = [
@@ -83,6 +84,7 @@ class MinerFundActivationTest(BitcoinTestFramework):
             '-enableminerfund',
             f'-exodusactivationtime={EXODUS_ACTIVATION_TIME}',
             f'-leviticusactivationtime={LEVITICUS_ACTIVATION_TIME}',
+            f'-numbersactivationtime={NUMBERS_ACTIVATION_TIME}',
         ]]
 
     def run_test(self):


### PR DESCRIPTION
Nodes automatically fork off from the network if not upgraded at the
determined timestamp. This change bumps the "fork off" timestamp
(replayprotectiontime) to 2023-06-21T14:58:00.000Z (Deuteronomy
upgrade), such that the node continues to accept normally signed
(non-replay protected) transactions at the "Numbers" network upgrade.