### PR TITLE
fix Python 3.10 asyncio DeprecationWarning

### DIFF
--- a/test/functional/interface_nng.py
+++ b/test/functional/interface_nng.py
@@ -57,7 +57,8 @@ class NngInterfaceTest(BitcoinTestFramework):
         self.anyone_script = self.nodes[0].validateaddress(self.anyone_addr)['scriptPubKey']
         self.anyone_addr2 = self.nodes[0].decodescript('52')['p2sh']
         self.anyone_script2 = self.nodes[0].validateaddress(self.anyone_addr2)['scriptPubKey']
-        asyncio.get_event_loop().run_until_complete(self._nng_test())
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(self._nng_test())
 
     async def _nng_test(self):
         import pynng, flatbuffers


### PR DESCRIPTION
[test] fix Python 3.10 asyncio DeprecationWarning

With Python 3.10, calling `asyncio.get_event_loop().run_until_complete`  raises a `DeprecationWarning`, which is interpreted as a failure by the test framework because there should be nothing on stderr.

```
Running Unit Tests for Test Framework Modules
..........
----------------------------------------------------------------------
Ran 10 tests in 0.059s

OK
interface_nng.py started
interface_nng.py failed, Duration: 2 s

stdout:
2022-11-01T07:38:25.753000Z TestFramework (INFO): Initializing test directory /home/pierre/dev/lotusd/build/test/tmp/test_runner_₿₵_🏃_20221101_083825/interface_nng_0
2022-11-01T07:38:27.486000Z TestFramework (INFO): Stopping nodes
2022-11-01T07:38:27.487000Z TestFramework (INFO): Cleaning up /home/pierre/dev/lotusd/build/test/tmp/test_runner_₿₵_🏃_20221101_083825/interface_nng_0 on exit
2022-11-01T07:38:27.487000Z TestFramework (INFO): Tests successful

stderr:
/home/pierre/dev/lotusd/test/functional/interface_nng.py:60: DeprecationWarning: There is no current event loop
  asyncio.get_event_loop().run_until_complete(self._nng_test())
```

With Python 3.11, this will become a `RuntimeError`.

This change  creates the loop before running it.

A simpler solution would be to just use `asyncio.run(self._nng_test())` which internally takes care of creating the loop. Unfortunately, `asyncio.run` was added in Python 3.7, and according to dependencies.md Python 3.6 is still supported.
