### PR TITLE
Add activation code for Judges upgrade

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -115,6 +115,8 @@ public:
         consensus.joshuaActivationTime = 1703215620;
         // 2024-06-20T20:51:00.000Z protocol upgrade
         consensus.judgesActivationTime = 1718916660;
+        // 2024-12-21T09:20:00.000Z protocol upgrade
+        consensus.ruthActivationTime = 1734772800;
 
         /**
          * The message start string is designed to be unlikely to occur in
@@ -262,6 +264,10 @@ public:
         consensus.judgesActivationTime =
             mainnetConsensus.judgesActivationTime -
             testnetActivationOffset;
+        // 2024-12-21T09:20:00.000Z protocol upgrade
+        consensus.ruthActivationTime =
+            mainnetConsensus.ruthActivationTime -
+            testnetActivationOffset;
 
         // "ltdk" with MSB set
         diskMagic[0] = 0xec;
@@ -376,6 +382,8 @@ public:
         consensus.joshuaActivationTime = mainnetConsensus.joshuaActivationTime;
         // 2024-06-20T20:51:00.000Z protocol upgrade
         consensus.judgesActivationTime = mainnetConsensus.judgesActivationTime;
+        // 2024-12-21T09:20:00.000Z protocol upgrade
+        consensus.ruthActivationTime = mainnetConsensus.ruthActivationTime;
 
         // "lrdk" with MSB set
         diskMagic[0] = 0xec;

--- a/src/consensus/activation.cpp
+++ b/src/consensus/activation.cpp
@@ -62,3 +62,13 @@ bool IsJoshuaEnabled(const Consensus::Params &params,
     return pindexPrev->GetMedianTimePast() >=
            gArgs.GetArg("-joshuaactivationtime", params.joshuaActivationTime);
 }
+
+bool IsJudgesEnabled(const Consensus::Params &params,
+                          const CBlockIndex *pindexPrev) {
+    if (pindexPrev == nullptr) {
+        return false;
+    }
+
+    return pindexPrev->GetMedianTimePast() >=
+           gArgs.GetArg("-judgesactivationtime", params.judgesActivationTime);
+}

--- a/src/consensus/activation.h
+++ b/src/consensus/activation.h
@@ -35,4 +35,8 @@ bool IsDeuteronomyEnabled(const Consensus::Params &params,
 bool IsJoshuaEnabled(const Consensus::Params &params,
                           const CBlockIndex *pindexPrev);
 
+/** Check if June 20th, 2024 protocol upgrade has activated. */
+bool IsJudgesEnabled(const Consensus::Params &params,
+                          const CBlockIndex *pindexPrev);
+
 #endif // BITCOIN_CONSENSUS_ACTIVATION_H

--- a/src/consensus/addresses.h
+++ b/src/consensus/addresses.h
@@ -137,5 +137,9 @@ Consensus::CoinbaseAddresses AddressSets = {
         {
             "lotus_16PSJJYp3YkVyctW8LRbp6UhbsrQMJghL3jjze3b7",
         },
+    .judges =
+        {
+            "lotus_16PSJMaps9sQg7aBQgyY1RdHb2fZYdmWhQPbgus75"
+        }
 };
 } // namespace RewardAddresses

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -21,6 +21,7 @@ struct CoinbaseAddresses {
     std::vector<std::string> numbers;
     std::vector<std::string> deuteronomy;
     std::vector<std::string> joshua;
+    std::vector<std::string> judges;
 };
 
 /**
@@ -47,6 +48,9 @@ struct Params {
     /** Unix time used for MTP activation of 2024-06-20T20:51:00.000Z protocol
      * upgrade */
     int judgesActivationTime;
+    /** Unit time used for MTP activation of 2024-12-21T09:20:00.000Z protocol
+     * upgrade */
+    int ruthActivationTime;
 
     /**
      * Don't warn about unknown BIP 9 activations below this height.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -426,7 +426,7 @@ void SetupServerArgs(NodeContext &node) {
         // TODO remove after the December 2021 upgrade
         "-exodusactivationtime", "-leviticusactivationtime",
         "-numbersactivationtime", "-deuteronomyactivationtime",
-        "-joshuaactivationtime"};
+        "-joshuaactivationtime", "-judgesactivationtime"};
 
     // Set all of the args and their help
     // When adding new options to the categories, please keep and ensure

--- a/src/minerfund.cpp
+++ b/src/minerfund.cpp
@@ -56,6 +56,11 @@ std::vector<CTxOut> GetMinerFundRequiredOutputs(const Consensus::Params &params,
         return {};
     }
 
+    if (IsJudgesEnabled(params, pindexPrev)) {
+        return BuildOutputsCycling(params.coinbasePayoutAddresses.judges,
+                                   pindexPrev, blockReward);
+    }
+
     if (IsJoshuaEnabled(params, pindexPrev)) {
         return BuildOutputsCycling(params.coinbasePayoutAddresses.joshua,
                                    pindexPrev, blockReward);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -278,7 +278,7 @@ bool CheckSequenceLocks(const CTxMemPool &pool, const CTransaction &tx,
 static bool IsReplayProtectionEnabled(const Consensus::Params &params,
                                       int64_t nMedianTimePast) {
     return nMedianTimePast >= gArgs.GetArg("-replayprotectionactivationtime",
-                                           params.judgesActivationTime);
+                                           params.ruthActivationTime);
 }
 
 static bool IsReplayProtectionEnabled(const Consensus::Params &params,

--- a/test/functional/logos_feature_minerfund_activation.py
+++ b/test/functional/logos_feature_minerfund_activation.py
@@ -124,7 +124,7 @@ JOSHUA_SCRIPTS = [
     "76a9142eedc5ad3d142181417daea01076846edfba998088ac",
 ]
 JUDGES_SCRIPTS = [
-    "76a9149208ecc785c92968481a92aee7024b77e54d27dc88ac"
+    "76a9149208ecc785c92968481a92aee7024b77e54d27dc88ac",
 ]
 
 class MinerFundActivationTest(BitcoinTestFramework):
@@ -352,10 +352,6 @@ class MinerFundActivationTest(BitcoinTestFramework):
             block = make_block_cb_post_numbers(JOSHUA_SCRIPTS)
             prepare_block(block)
             assert_equal(node.submitblock(ToHex(block)), None)
-
-        ###
-        ### 2024-12-21T09:20:00.000Z Judges protocol upgrade
-        ###
 
         # Using the judges addresses before upgrade fails
         block = make_block_cb_post_numbers(JUDGES_SCRIPTS)

--- a/test/functional/logos_feature_minerfund_activation.py
+++ b/test/functional/logos_feature_minerfund_activation.py
@@ -357,7 +357,7 @@ class MinerFundActivationTest(BitcoinTestFramework):
         block = make_block_cb_post_numbers(JUDGES_SCRIPTS)
         prepare_block(block)
         assert_equal(node.submitblock(ToHex(block)), 'bad-cb-minerfund')
-        node.setmocktime(JOSHUA_ACTIVATION_TIME)
+        node.setmocktime(JUDGES_ACTIVATION_TIME)
 
         # Mine 11 blocks with JUDGES_ACTIVATION in the middle
         # That moves MTP exactly to JUDGES_ACTIVATION


### PR DESCRIPTION
Make all necessary preparations for the Judges upgrade June 20 2024. Used previous Joshua upgrade commits as template for this commit.

~Still need to add the Python test.~ [f6ba1a7](https://github.com/givelotus/lotusd/pull/314/commits/f6ba1a7686428970bcdb9ec53e844e21d1adafe0)